### PR TITLE
CO-583/newlines-textplain

### DIFF
--- a/src/main/java/fr/openent/zimbra/model/message/Multipart.java
+++ b/src/main/java/fr/openent/zimbra/model/message/Multipart.java
@@ -82,6 +82,7 @@ public class Multipart {
             String content = mpart.getString(MULTIPART_CONTENT, "");
             if (MULTIPART_CT_TEXTPLAIN.equals(contentType)) {
                 content = escapeHtml4(content);
+                content = content.replace("\n","<br/>");
             }
             this.body += content;
         } else {


### PR DESCRIPTION
Lorsqu'on envoie un message en texte brut, les fins de lignes de s'affichaient pas en mode simple