### PR TITLE
CO-744 : Fix non-profile groups in AddressBook Synchronization

### DIFF
--- a/src/main/java/fr/openent/zimbra/service/data/Neo4jAddrbookService.java
+++ b/src/main/java/fr/openent/zimbra/service/data/Neo4jAddrbookService.java
@@ -164,8 +164,8 @@ public class Neo4jAddrbookService {
         queryGeneric += "AND (( (length(p) >= 2 OR m.users <> 'INCOMING') AND (length(p) < 3 OR (ipg:Group AND (m:User OR g<-[:DEPENDS]-m) AND length(p) = 3)))) ";
         queryGeneric += "AND (m:User OR exists(m-[:IN]-(:User))) ";
         queryGeneric += "WITH DISTINCT m as visibles ";
-        queryGeneric += "MATCH (visibles-[:IN*0..1]-(pgs:ProfileGroup)-[:DEPENDS*1..2]-(s:Structure)) ";
-        queryGeneric += "WHERE s.UAI = {uai} ";
+        queryGeneric += "MATCH (visibles-[:IN*0..1]-(pgs:Group)-[:DEPENDS*1..2]-(s:Structure)) ";
+        queryGeneric += "WHERE s.UAI = {uai} AND (visibles:Group OR pgs:ProfileGroup) ";
         queryGeneric += "OPTIONAL MATCH pgs-[:DEPENDS*0..1]->(pg:ProfileGroup)-[:HAS_PROFILE]->(profile:Profile) ";
         queryGeneric += getOptionalMatchesUser("visibles", "c", "fg", "subj");
         queryGeneric += "RETURN distinct visibles.lastName as " + LASTNAME + ", ";

--- a/src/main/resources/i18n/fr.json
+++ b/src/main/resources/i18n/fr.json
@@ -191,7 +191,6 @@
     "zimbra.message.error.attachment": "Une erreur est survenue lors de l'ajout de la pièce jointe, vérifiez la taille de votre mail",
     "zimbra.message.error.mail.size": "La taille de vos pièces jointes est trop importante, vérifiez la taille de votre mail",
     "zimbra.message.info.iframe": "Le mail contient un code HTML qui n'est pas interprété, vous ne pourrez pas l'envoyer (iframe)",
-    "zimbra.message.error.mail.size": "La taille de vos pièces jointes est trop importante, vérifiez la taille de votre mail",
     "zimbra.message.error.get.favorite": "Une erreur est survenue lors de la récupération du groupe favori",
     "zimbra.message.error.get.user": "Une erreur est survenue lors de la récupération de utilisateur",
     "zimbra.message.error.get.group": "Une erreur est survenue lors de la récupération du groupe",

--- a/src/main/resources/public/ts/controllers/controller.ts
+++ b/src/main/resources/public/ts/controllers/controller.ts
@@ -16,7 +16,7 @@
  */
 
 import {$, _, Document, idiom as lang, moment, ng, notify, skin, template} from "entcore";
-import {ViewMode, Mail, quota, SCREENS, SystemFolder, User, UserFolder, Zimbra, REGEXLIB, RECEIVER_TYPE} from "../model";
+import {ViewMode, Mail, quota, SCREENS, SystemFolder, User, UserFolder, Zimbra, REGEXLIB, RECEIVER_TYPE, Group, Users} from "../model";
 
 import {Mix} from "entcore-toolkit";
 import {Preference} from "../model/preferences";


### PR DESCRIPTION
Affichage des groupes manuels et groupes d'enseignements dans les carnets d'adresse Zimbra pour les comptes ne pouvant pas communiquer vers l'extérieur.