### PR TITLE
fix(attachment): [MZI-29] get attachment from workspace

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ subprojects {
   dependencies {
     compileOnly "io.vertx:vertx-core:$vertxVersion"
     compile "io.vertx:vertx-circuit-breaker:$vertxVersion"
+    compile "io.vertx:vertx-web-client:$vertxVersion"
     compile "org.entcore:common:$entCoreVersion"
     testCompile "io.vertx:vertx-unit:$vertxVersion"
     testCompile "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,4 +33,4 @@ mockitoVersion=2.+
 vertxCronTimer=2.0.0
 webUtilsVersion=2.0.3
 
-entCoreVersion=4.4-SNAPSHOT
+entCoreVersion=4.4.1-SNAPSHOT

--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -19,6 +19,7 @@ package fr.openent.zimbra.controllers;
 
 import fr.openent.zimbra.Zimbra;
 import fr.openent.zimbra.filters.DevLevelFilter;
+import fr.openent.zimbra.filters.AccessibleDocFilter;
 import fr.openent.zimbra.helper.AsyncHelper;
 import fr.openent.zimbra.helper.ConfigManager;
 import fr.openent.zimbra.helper.ServiceManager;
@@ -47,17 +48,22 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.auth.User;
 import org.entcore.common.cache.Cache;
 import org.entcore.common.cache.CacheOperation;
 import org.entcore.common.cache.CacheScope;
 import org.entcore.common.events.EventStore;
 import org.entcore.common.events.EventStoreFactory;
 import org.entcore.common.http.filter.ResourceFilter;
+import org.entcore.common.storage.Storage;
+import org.entcore.common.storage.StorageFactory;
+import org.entcore.common.user.UserInfos;
 import org.entcore.common.user.UserUtils;
 import org.entcore.common.utils.Config;
 import org.vertx.java.core.http.RouteMatcher;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -80,13 +86,13 @@ public class ZimbraController extends BaseController {
     private RedirectionService redirectionService;
     private FrontPageService frontPageService;
     private AddressBookService addressBookService;
-
-
+    private Storage storage;
     private EventStore eventStore;
+
 
     private enum ZimbraEvent {ACCESS, CREATE}
 
-
+    private static final String WORKSPACE_BUS_ADDRESS = "org.entcore.workspace";
     private static final Logger log = LoggerFactory.getLogger(ZimbraController.class);
 
     @Override
@@ -95,6 +101,8 @@ public class ZimbraController extends BaseController {
         super.init(vertx, config, rm, securedActions);
 
         eventStore = EventStoreFactory.getFactory().getEventStore(Zimbra.class.getSimpleName());
+        storage = new StorageFactory(vertx, config).getStorage();
+
 
         ServiceManager serviceManager = ServiceManager.init(vertx, eb, pathPrefix);
 
@@ -506,6 +514,32 @@ public class ZimbraController extends BaseController {
                 });
             } else {
                 unauthorized(request);
+            }
+        });
+    }
+
+    @Post("message/:id/upload/:idAttachment")
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(AccessibleDocFilter.class)
+    public void uploadAttachment(final HttpServerRequest request) {
+        final String id = request.params().get("id");
+        final String idAttachment = request.params().get("idAttachment");
+        attachmentService.getDocument(eb, idAttachment, event -> {
+            if (event.isRight()) {
+                JsonObject document = event.right().getValue();
+                String file = document.getString("file");
+                storage.readStreamFile(file, buffer->{
+                    if(buffer==null){
+                        notFound(request);
+                    } else {
+
+                        String userId = document.getString("owner");
+                        UserInfos user = new UserInfos();
+                        user.setUserId(userId);
+
+                        attachmentService.addAttachment(id, user, buffer, document, defaultResponseHandler(request));
+                    }
+                });
             }
         });
     }
@@ -1008,7 +1042,6 @@ public class ZimbraController extends BaseController {
         });
     }
 
-
     /**
      * Post an new attachment to a drafted message.
      * In case of success, return Json Object :
@@ -1031,7 +1064,7 @@ public class ZimbraController extends BaseController {
             }
 
             request.pause();
-            attachmentService.addAttachment(messageId, user, request, defaultResponseHandler(request));
+            attachmentService.addAttachmentBuffer(messageId, user, request, defaultResponseHandler(request));
         });
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -1,0 +1,18 @@
+package fr.openent.zimbra.core.constants;
+
+public class Field {
+
+    private Field() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static final String CONTENT_TYPE = "Content-Type";
+
+    public static final String CONTENT_DISPOSITION = "Content-Disposition";
+
+    public static final String COOKIE = "Cookie";
+
+    public static final String AUTH_TOKEN = "authToken";
+
+    public static final String NAME = "name";
+}

--- a/zimbra/src/main/java/fr/openent/zimbra/filters/AccessibleDocFilter.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/filters/AccessibleDocFilter.java
@@ -1,0 +1,64 @@
+package fr.openent.zimbra.filters;
+
+import com.mongodb.DBObject;
+import com.mongodb.QueryBuilder;
+
+import static org.entcore.common.mongodb.MongoDbResult.validActionResultHandler;
+
+import fr.wseduc.mongodb.MongoDb;
+import fr.wseduc.mongodb.MongoQueryBuilder;
+import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.user.UserInfos;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AccessibleDocFilter implements ResourcesProvider {
+
+    private MongoDb mongo = MongoDb.getInstance();
+    private static final Logger log = LoggerFactory.getLogger(AccessibleDocFilter.class);
+
+    /**
+     * Used for shared documents. Gets the documents the user is allowed to send and get from workspace (security).
+     * Takes into account if the user is part of a group
+     * @param request
+     * @param binding
+     * @param user
+     * @param handler
+     */
+    @Override
+    public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
+
+        QueryBuilder builder = new QueryBuilder();
+        String id = request.params().get("idAttachment");
+
+        List<DBObject> groups = new ArrayList<>();
+        groups.add(QueryBuilder.start("userId").is(user.getUserId()).get());
+        for (String gpId : user.getGroupsIds()) {
+            groups.add(QueryBuilder.start("groupId").is(gpId).get());
+        }
+        DBObject subQuery = new QueryBuilder().or(groups.toArray(new DBObject[groups.size()])).get();
+        builder.and(QueryBuilder.start("_id").is(id).get())
+                .and(new QueryBuilder().or(
+                        QueryBuilder.start("owner").is(user.getUserId()).get(),
+                        QueryBuilder.start("shared").elemMatch(subQuery).get()).get());
+
+        mongo.count("documents", MongoQueryBuilder.build(builder), validActionResultHandler(result -> {
+            if (result.isLeft()) {
+                log.error("An error has occured while finding targeted document: ", result.left().getValue());
+                handler.handle(false);
+            } else {
+                if (result.right().getValue().getInteger("count") <= 0) {
+                    log.error("An error has occured while finding targeted document. Access denied");
+                    handler.handle(false);
+                } else {
+                    handler.handle(true);
+                }
+            }
+        }));
+    }};

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/HttpClientHelper.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/HttpClientHelper.java
@@ -24,9 +24,39 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.core.net.ProxyOptions;
+import io.vertx.ext.web.client.WebClientOptions;
 
 public class HttpClientHelper {
     private static final Logger log = LoggerFactory.getLogger(HttpClientHelper.class);
+
+    /**
+     * get default Proxy options
+     * @return proxyOptions
+     */
+    public static ProxyOptions proxyOptions() {
+        return new ProxyOptions()
+                .setHost(System.getProperty("httpclient.proxyHost"))
+                .setPort(Integer.parseInt(System.getProperty("httpclient.proxyPort")))
+                .setUsername(System.getProperty("httpclient.proxyUsername"))
+                .setPassword(System.getProperty("httpclient.proxyPassword"));
+    }
+
+    /**
+     * Create default WebClientOptions
+     * @return new WebClientOptions
+     */
+    public static WebClientOptions getWebClientOptions() {
+        WebClientOptions options = new WebClientOptions();
+        if (System.getProperty("httpclient.proxyHost") != null) {
+            options.setProxyOptions(HttpClientHelper.proxyOptions());
+        }
+        int maxPoolSize = Zimbra.appConfig.getHttpClientMaxPoolSize();
+        if(maxPoolSize > 0) {
+            options.setMaxPoolSize(maxPoolSize);
+        }
+        return options;
+    }
+
     /**
      * Create default HttpClient
      * @return new HttpClient
@@ -34,11 +64,7 @@ public class HttpClientHelper {
     public static HttpClient createHttpClient(Vertx vertx) {
         final HttpClientOptions options = new HttpClientOptions();
         if (System.getProperty("httpclient.proxyHost") != null) {
-            ProxyOptions proxyOptions = new ProxyOptions()
-                    .setHost(System.getProperty("httpclient.proxyHost"))
-                    .setPort(Integer.parseInt(System.getProperty("httpclient.proxyPort")))
-                    .setUsername(System.getProperty("httpclient.proxyUsername"))
-                    .setPassword(System.getProperty("httpclient.proxyPassword"));
+            ProxyOptions proxyOptions = proxyOptions();
             options.setProxyOptions(proxyOptions);
         }
         int maxPoolSize = Zimbra.appConfig.getHttpClientMaxPoolSize();

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/ServiceManager.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/ServiceManager.java
@@ -28,6 +28,7 @@ import fr.wseduc.webutils.email.EmailSender;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.WebClient;
 import org.entcore.common.cache.CacheService;
 import org.entcore.common.cache.RedisCacheService;
 import org.entcore.common.email.EmailFactory;
@@ -72,6 +73,7 @@ public class ServiceManager {
     private SynchroMailerService synchroMailerService;
     private SynchroAddressBookService synchroAddressBookService;
     private Neo4jAddrbookService neo4jAddrbookService;
+    private WebClient webClient;
 
     private SynchroLauncher synchroLauncher;
 
@@ -92,6 +94,8 @@ public class ServiceManager {
         String redisConfig = (String) vertx.sharedData().getLocalMap("server").get("redisConfig");
         CacheService cacheService = redisConfig != null ? new RedisCacheService(Redis.getClient()) : null;
 
+        this.webClient = WebClient.create(vertx, HttpClientHelper.getWebClientOptions());
+
         this.slackService = new SlackService(vertx, appConfig.getSlackConfiguration());
 
         this.sqlSynchroService = new SqlSynchroService(appConfig.getDbSchema());
@@ -109,7 +113,7 @@ public class ServiceManager {
         this.signatureService = new SignatureService(userService, soapService);
         this.messageService = new MessageService(soapService, folderService,
                 dbMailServiceApp, userService, synchroUserService);
-        this.attachmentService = new AttachmentService(soapService, messageService, vertx, rawConfig);
+        this.attachmentService = new AttachmentService(soapService, messageService, vertx, rawConfig, webClient);
         this.notificationService = new NotificationService(pathPrefix, timelineHelper);
         this.communicationService = new CommunicationService();
         this.groupService = new GroupService(soapService, dbMailServiceApp, synchroUserService);
@@ -268,4 +272,8 @@ public class ServiceManager {
     public SqlAddressBookService getSqlAddressBookService() { return sqlAddressBookService; }
 
     public ReturnedMailService getReturnedMailService() { return returnedMailService; }
+
+    public WebClient getWebClient() {
+        return webClient;
+    }
 }

--- a/zimbra/src/main/resources/i18n/fr.json
+++ b/zimbra/src/main/resources/i18n/fr.json
@@ -199,6 +199,7 @@
     "folder.OtherGroups": "Autres Groupes",
     "Teacher": "Enseignant",
     "zimbra.message.error.attachment": "Une erreur est survenue lors de l'ajout de la pièce jointe, vérifiez la taille de votre mail",
+    "zimbra.message.error.attachments": "Une erreur est survenue lors de l'ajout de la pièce jointe",
     "zimbra.message.error.mail.size": "La taille de vos pièces jointes est trop importante, vérifiez la taille de votre mail",
     "zimbra.message.info.iframe": "Le mail contient un code HTML qui n'est pas interprété, vous ne pourrez pas l'envoyer (iframe)",
     "zimbra.message.error.get.favorite": "Une erreur est survenue lors de la récupération du groupe favori",

--- a/zimbra/src/main/resources/public/sass/global/_conversation.scss
+++ b/zimbra/src/main/resources/public/sass/global/_conversation.scss
@@ -174,6 +174,33 @@
       }
     }
   }
+
+  i.loaded{
+    @include fonticon;
+    transform: rotate(0deg);
+    &::before{
+      content: '\e915';
+    }
+  }
+
+  button.flat-button{
+    &.file-button[disabled=disabled]{
+      background-color: #8C939E;
+      color: #B1B6BF;
+      pointer-events: none;
+    }
+  }
+
+  i.loading{
+    animation: rotate 1000ms linear infinite;
+    @include fonticon;
+    display: inline-block;
+    &::before{
+      content: '\e85a';
+    }
+  }
+
+
   #folder-loader {
     padding-top: 100px;
     .spinner {

--- a/zimbra/src/main/resources/public/template/mail-actions/write-mail.html
+++ b/zimbra/src/main/resources/public/template/mail-actions/write-mail.html
@@ -164,7 +164,6 @@
                 <i18n>attachments.loading</i18n>
             </h2>
             <hr class="line no-margin" />
-
             <div class="loading-list no-padding vertical-spacingm-twice">
                 <ul>
                     <li class="no-margin" ng-repeat="attachment in state.newItem.loadingAttachments">
@@ -181,7 +180,7 @@
 	</div>
 
     <!-- attachment list loaded -->
-    <div class="loading-list no-padding vertical-spacing-twice" ng-init="columnOrder = 'filename'" drop-files="state.newItem.newAttachments" on-drop="postAttachments()" ng-if="state.newItem.attachments.length">
+    <div class="loading-list no-padding vertical-spacing-twice" ng-init="columnOrder = 'filename'" ng-if="state.newItem.attachments.length">
         <ul>
             <li class="no-margin removable" ng-repeat="attachment in state.newItem.attachments | orderBy: columnOrder">
                 <div class="icon">
@@ -190,15 +189,23 @@
                 <div class="title">
                     [[attachment.filename]]
                 </div>
+
                 <div class="status-infos">
+                    <i ng-class="{
+                            loading: attachment.uploadStatus === 'loading',
+                            loaded: attachment.uploadStatus === 'loaded',
+                            failed: attachment.uploadStatus === 'failed'
+                    }"></i>
                     <span class="small-text reduce-block-four">[[formatSize(attachment.size)]]</span>
                 </div>
-                <a ng-href="[['message/'+state.newItem.id+'/attachment/'+attachment.id]]" class="fade-in-hover large-text reduce-block-four">
+                <a ng-href="[['message/'+state.newItem.id+'/attachment/'+attachment.id]]"
+                   class="fade-in-hover large-text reduce-block-four">
                     <i class="download-disk valid-color" tooltip="download"></i>
                 </a>
                 <i class="close"
                    ng-click="deleteAttachment($event, attachment, state.newItem)"
                    ng-disabled="(state.newItem.loadingAttachments && state.newItem.loadingAttachments.length > 0)"
+                   ng-if="!isFileLoading"
                    tooltip="remove.attachment">
                 </i>
             </li>
@@ -206,12 +213,13 @@
     </div>
 
     <div class="right-magnet select-file ">
-        <button ng-click="showAttachmentLightbox()" class="flat-button file-button" translate="" content="add.attachment"></button>
+        <button ng-click="showAttachmentLightbox()" ng-disabled="isFileLoading" class="flat-button file-button" translate="" content="add.attachment"></button>
     </div>
 </article>
 
 <lightbox show="displayLightBox.attachment" on-close="displayLightBox.attachment = false">
     <div ng-if="displayLightBox.attachment">
-        <media-library ng-model="attachmentOption.display.files" ng-change="uploadAttachment(attachmentOption.display.files);" file-format="'any'"></media-library>
+        <media-library ng-model="attachmentOption.display.files"
+                       ng-change="uploadAttachment(attachmentOption.display.files);" file-format="'any'"></media-library>
     </div>
 </lightbox>

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -15,8 +15,22 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-import {$, _, Document, idiom as lang, moment, ng, notify, skin, template, angular, workspace} from "entcore";
-import {ViewMode, Mail, quota, SCREENS, SystemFolder, User, UserFolder, Zimbra, REGEXLIB, RECEIVER_TYPE, Group, Users, Attachment} from "../model";
+import {$, _, angular, Document, idiom as lang, moment, ng, notify, skin, template} from "entcore";
+import {
+    Attachment,
+    Group,
+    Mail,
+    quota,
+    RECEIVER_TYPE,
+    REGEXLIB,
+    SCREENS,
+    SystemFolder,
+    User,
+    UserFolder,
+    Users,
+    ViewMode,
+    Zimbra
+} from "../model";
 
 
 import {Preference} from "../model/preferences";
@@ -983,13 +997,8 @@ export let zimbraController = ng.controller("ZimbraController", [
             );
         };
 
-        $scope.deleteAttachment = function(event, attachment, mail) {
-            const response = mail.deleteAttachment(attachment);
-
-            this.attachments = response.data.attachments;
-            this.attachments.map(attachment => {
-                attachment.filename = decodeURI(attachment.filename);
-            })
+        $scope.deleteAttachment = async function (event, attachment, mail) {
+            await mail.deleteAttachment(attachment);
             $scope.isFileLoading = false;
             $scope.$apply();
         };
@@ -997,15 +1006,13 @@ export let zimbraController = ng.controller("ZimbraController", [
         $scope.quota = quota;
 
         $scope.countDraft = async (folderSource, folderTarget) => {
-            var draft =
-                folderSource.getName() === "DRAFT" ||
+            return folderSource.getName() === "DRAFT" ||
                 folderTarget.getName() === "DRAFT";
-            return draft;
         };
 
         $scope.emptyTrash = async () => {
             $scope.lightbox.show = true;
-            template.open("lightbox", "empty-trash");
+            await template.open("lightbox", "empty-trash");
         };
 
         $scope.removeTrashMessages = async () => {

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -500,6 +500,9 @@ export class Mail implements Selectable {
         this.attachments.splice(this.attachments.indexOf(attachment), 1);
         const response = await http.delete("message/" + this.id + "/attachment/" + attachment.id);
         this.attachments = response.data.attachments;
+        this.attachments.map(attachment => {
+            attachment.filename = decodeURI(attachment.filename);
+        })
     }
 
     rewriteBody() {

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -38,24 +38,20 @@ import {MAIL, SERVICE, QUOTA} from "./constantes";
 
 export class Attachment {
     file: File;
-    progress: {
-        total: number;
-        completion: number;
-    };
+    uploadStatus: string;
     id: string;
     filename: string;
     size: number;
     contentType: string;
 
-    constructor(file: File) {
+    constructor(file: any) {
         this.file = file;
-        this.progress = {
-            total: 100,
-            completion: 0
-        };
+        this.uploadStatus = "loading";
+        this.filename = file.metadata.filename;
+        this.size = file.metadata.size;
+        this.id = file._id;
     }
 }
-
 export class Mail implements Selectable {
     id: string;
     date: string;
@@ -403,6 +399,11 @@ export class Mail implements Selectable {
             Zimbra.instance.currentFolder.nbUnread--;
         }
         let response = await http.get("/zimbra/message/" + this.id);
+
+        response.data.attachments.map(attachment => {
+            attachment.filename = decodeURI((attachment.filename));
+        })
+
         Mix.extend(this, response.data);
         this.to = this.to.map(user =>
             Mix.castAs(User, {
@@ -474,66 +475,31 @@ export class Mail implements Selectable {
         await Zimbra.instance.folders.draft.mails.refresh();
     }
 
-    async postAttachments($scope) {
-        for (let i = 0; i < this.newAttachments.length; i++) {
-            const targetAttachment = this.newAttachments[i];
-            const attachmentObj = new Attachment(targetAttachment);
-            this.loadingAttachments.push(attachmentObj);
+    async postAttachment($scope, attachment: Attachment) {
+        attachment.uploadStatus = "loading";
 
-            const promise = http
-                .post(
-                    "message/" + this.id + "/attachment",
-                    attachmentObj.file,
-                    {
-                        headers: {
-                            "Content-Disposition":
-                                'attachment; filename="' +
-                                attachmentObj.file.name.replace(
-                                    /[\u00A0-\u9999<>\&]/gim,
-                                    function (i) {
-                                        return "&#" + i.charCodeAt(0) + ";";
-                                    }
-                                ) +
-                                '"'
-                        },
-                        onUploadProgress: (e: ProgressEvent) => {
-                            if (e.lengthComputable) {
-                                var percentage = Math.round(
-                                    (e.loaded * 100) / e.total
-                                );
-                                attachmentObj.progress.completion = percentage;
-                                $scope.$apply();
-                            }
-                        }
-                    }
-                )
-                .then(async response => {
-                    this.loadingAttachments.splice(
-                        this.loadingAttachments.indexOf(attachmentObj),
-                        1
-                    );
-                    this.attachments = response.data.attachments;
-                    quota.refresh();
-                    $scope.$apply();
-                })
-                .catch(e => {
-                    this.loadingAttachments.splice(
-                        this.loadingAttachments.indexOf(attachmentObj),
-                        1
-                    );
-                    sendNotificationErrorZimbra(e.response.data.error);
+        http
+            .post(`/zimbra/message/${$scope.state.newItem.id}/upload/${attachment.id}`)
+            .then(async response => {
+                this.attachments = response.data.attachments as Attachment[];
+                this.attachments.map(attach => {
+                    attach.filename = decodeURI(attach.filename);
+                    attach.uploadStatus = "loaded";
                 });
-            await Promise.resolve(promise);
-        }
+                $scope.isFileLoading = false;
+                $scope.$apply();
+            })
+            .catch(e => {
+                $scope.isFileLoading = false;
+                $scope.$apply();
+                sendNotificationErrorZimbra(e.response.data.error);
+            });
     }
 
     async deleteAttachment(attachment) {
         this.attachments.splice(this.attachments.indexOf(attachment), 1);
-        const response = await http.delete(
-            "message/" + this.id + "/attachment/" + attachment.id
-        );
+        const response = await http.delete("message/" + this.id + "/attachment/" + attachment.id);
         this.attachments = response.data.attachments;
-        quota.refresh();
     }
 
     rewriteBody() {
@@ -723,7 +689,6 @@ export class Mails {
             "/zimbra/trash?" +
             toFormData({id: _.pluck(this.selection.selected, "id")})
         );
-        quota.refresh();
         this.selection.removeSelection();
     }
 


### PR DESCRIPTION
## Describe your changes
Permet d'obtenir des fichiers depuis workspace pour les mettre en pièces jointes dans zimbra
Les fichiers sont transmis sous la forme de ReadStream<Buffer> pour ne pas prendre toute la place en mémoire.
Il a donc fallu faire des modifications dans l'entcore. Se référer à la PR : 
https://github.com/opendigitaleducation/entcore/pull/281



## Checklist tests
- Les fichiers chargent correctement en pièce jointe
- Les fichiers sont téléchargeables une fois le mail reçu
- Le symbole de chargement s'affiche tant que la pièce jointe n'est pas chargé et il est impossible de charger une autre pièce jointe pendant la durée du chargement (bouton grisé et non cliquable)
- Les pièces jointes ne sont pas supprimables tant qu'une est en chargement

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MZI-29

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)