### PR TITLE
feat(workspace): #MZI-90 replace writeBuffer with stream mode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,4 +33,4 @@ mockitoVersion=2.+
 vertxCronTimer=2.0.0
 webUtilsVersion=2.9.9
 
-entCoreVersion=4.6-SNAPSHOT
+entCoreVersion=4.6.0


### PR DESCRIPTION
## Describe your changes

Reprise du ticket #27 et #30 

On utilise l'implémentation `writeBufferStream` pour télécharger le fichier dans l'espace documentaire.

⚠️ A merger la PR entcore https://github.com/opendigitaleducation/entcore/pull/299 avant de merger celle-ci

⚠️ Pour pouvoir l'intégrer sur dev, il faudra la PR https://github.com/opendigitaleducation/entcore/pull/299 soit intégré pour avoir une version **4.6-SNAPSHOT**
⚠️ Pour pouvoir l'intégrer sur master, il faudra faire une montée de version côté entcore en release avant de procéder au **tag** avec ce commit

## Checklist tests

- [x] Jobs CI back -> doit correctement être compilé -> KO https://github.com/OPEN-ENT-NG/zimbra-connector/actions/runs/3262906855/jobs/5360757201 
En attente de validation de la PR entcore : https://github.com/opendigitaleducation/entcore/pull/299

- [x] zimbra -> /zimbra/zimbra#/inbox -> aller sur un mail avec un Pj en icon et télécharger dans l'espace document 
- [x] On retrouve le contenu dans l'espace doc

## Issue ticket number and link

https://jira.support-ent.fr/browse/MZI-90

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)