### PR TITLE
fix: #MZI-84 display the right mail in the return mail popup

### DIFF
--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -186,7 +186,7 @@ export let zimbraController = ng.controller("ZimbraController", [
             if(group.id){
                 group.isGroup = true;
                 $scope.addUser(group);
-            };
+            }
         };
 
         const initFavoriteTo = async (idGroupFavorite:string):Promise<void> => {
@@ -258,6 +258,7 @@ export let zimbraController = ng.controller("ZimbraController", [
                 folderName = (Zimbra.instance.currentFolder as SystemFolder)
                     .folderName;
             }
+            $scope.mail = undefined;
             $scope.state.newItem = new Mail();
             $scope.state.newItem.setMailSignature($scope.getSignature());
             template.open("right-side","right-side");


### PR DESCRIPTION
## Describe your changes

Display the correct mail subjet in the return mail popup

## Checklist tests

1. Go to /zimbra/zimbra
2. Open a mail
3. Click on "Messages envoyés" or "Outbox"
4. Select a mail
5. Check that the mail subjet matches the selected mail

## Issue ticket number and link

[JIRA#MZI-84](https://jira.support-ent.fr/browse/MZI-84)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)