### PR TITLE
fix: #MZI-11 handle error when uploading an attachment too big

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,7 @@ zimbraLang = ${String}
     "address-book-account" : "$zimbraAddressBookAccount",
     "admin-password" : "$zimbraAdminPassword",
     "zimbra-synchro-cron" : "$zimbraSynchroCron",
+    "zimbra-file-upload-max-size": $zimbraFileUploadMaxSize,
     "mail-config" : {
       "imaps":{
         ...
@@ -98,6 +99,7 @@ zimbraAdminAccount = ${String}
 zimbraAddressBookAccount = ${String}
 zimbraAdminPassword = ${String}
 zimbraSynchroCron = ${String}
+zimbraFileUploadMaxSize= ${Integer}
 zimbraPurgeEmailedContacts = boolean
 zimbraForceSyncAdressBook = boolean
 saveDraftAutoTime = ${String}

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ subprojects {
     compile "io.vertx:vertx-web-client:$vertxVersion"
     compile "org.entcore:common:$entCoreVersion"
     testCompile "io.vertx:vertx-unit:$vertxVersion"
+    testCompile "io.vertx:vertx-codegen:$vertxVersion"
     testCompile "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     testCompile "org.entcore:tests:$entCoreVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"

--- a/zimbra/deployment/zimbra/conf.j2
+++ b/zimbra/deployment/zimbra/conf.j2
@@ -24,6 +24,7 @@
         "admin-account" : "{{ zimbraAdminAccount }}",
         "admin-password" : "{{ zimbraAdminPassword }}",
         "max-recipients" : {{ zimbraMaxRecipients }},
+        "zimbra-file-upload-max-size": {{ zimbraFileUploadMaxSize | default('20') }},
         {% if zimbraCron is defined and zimbraCron %}
         "zimbra-synchro-cron" : "0 5/10 * * * ? *",
         "zimbra-mailer-cron" : "0 0/10 * * * ? *",

--- a/zimbra/deployment/zimbra/conf.json.template
+++ b/zimbra/deployment/zimbra/conf.json.template
@@ -26,6 +26,7 @@
     "address-book-account" : "$zimbraAddressBookAccount",
     "admin-password" : "$zimbraAdminPassword",
     "zimbra-synchro-cron" : "$zimbraSynchroCron",
+    "zimbra-file-upload-max-size": $zimbraFileUploadMaxSize,
     "mail-config" : {
       "imaps":{
         "server":"mx.monlycee.net",

--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -21,7 +21,6 @@ public class Field {
     public static  final String HTTPCLIENT = "httpClient";
     public static  final String ZIMBRARESPONSE = "zimbraResponse";
 
-
-
-
+    public static final String MAIL_ATTACHMENT_TOO_BIG = "mail.ATTACHMENT_TOO_BIG";
+    public static final String MAIL_INVALID_REQUEST = "mail.INVALID_REQUEST";
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/ConfigManager.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/ConfigManager.java
@@ -51,6 +51,7 @@ public class ConfigManager {
     private final String zimbraAdminPassword;
     private final String preauthKey;
     private final String zimbraDomain;
+    private final Integer zimbraFileUploadMaxSize;
 
     private final String synchroLang;
     private final String synchroCronDate;
@@ -110,6 +111,7 @@ public class ConfigManager {
         this.synchroLang = config.getString("zimbra-synchro-lang", "fr");
         this.synchroCronDate = config.getString("zimbra-synchro-cron", "");
         this.synchroFromMail = config.getString("zimbra-synchro-frommail", "zimbra-sync@cgi.com");
+        this.zimbraFileUploadMaxSize = config.getInteger("zimbra-file-upload-max-size", 20);
         String appSynchroType = config.getString("app-synctype", SYNC_NEO);
         String syncSynchroType = config.getString("sync-synctype", SYNC_NEO);
         this.appSyncTtl = config.getString("app-sync-ttl", "30 minutes");
@@ -181,6 +183,7 @@ public class ConfigManager {
     public String getZimbraAdminPassword() { return zimbraAdminPassword;}
     public String getPreauthKey() { return preauthKey;}
     public String getZimbraDomain() { return zimbraDomain;}
+    public Integer getZimbraFileUploadMaxSize() { return zimbraFileUploadMaxSize;}
     public String getAppSynchroType() { return appSynchroType;}
     public String getSyncSynchroType() { return syncSynchroType;}
     public String getAppSyncTtl() { return appSyncTtl;}

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/AttachmentService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/AttachmentService.java
@@ -17,6 +17,7 @@
 
 package fr.openent.zimbra.service.impl;
 
+import fr.openent.zimbra.Zimbra;
 import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.helper.FileHelper;
 import fr.openent.zimbra.helper.HttpClientHelper;
@@ -302,7 +303,7 @@ public class AttachmentService {
                             if (response.statusCode() == 200) {
                                     if (!(Pattern.compile("^.*\"aid\"\\s*:\\s*\"([^\"]*)\".*\n$")).matcher(response.bodyAsString()).find()) {
                                         JsonObject res = new JsonObject()
-                                                .put("code", "mail.INVALID_REQUEST");
+                                                .put("code", Field.MAIL_INVALID_REQUEST);
                                         handler.handle(new Either.Left<>(res.encode()));
                                         return;
                                     }
@@ -344,8 +345,15 @@ public class AttachmentService {
                 if(response.statusCode() == 200) {
                     response.bodyHandler( body -> {
                         if (!(Pattern.compile("^.*\"aid\"\\s*:\\s*\"([^\"]*)\".*\n$")).matcher(body.toString()).find()) {
+                            if (body.toString().matches("^413.*\n$")) {
+                                JsonObject res = new JsonObject()
+                                        .put("code", Field.MAIL_ATTACHMENT_TOO_BIG)
+                                        .put("maxFileSize", Zimbra.appConfig.getZimbraFileUploadMaxSize());
+                                handler.handle(new Either.Left<>(res.encode()));
+                                return;
+                            }
                             JsonObject res = new JsonObject()
-                                    .put("code", "mail.INVALID_REQUEST");
+                                    .put("code", Field.MAIL_INVALID_REQUEST);
                             handler.handle(new Either.Left<>(res.encode()));
                             return;
                         }

--- a/zimbra/src/main/resources/i18n/fr.json
+++ b/zimbra/src/main/resources/i18n/fr.json
@@ -210,6 +210,7 @@
     "Relative": "Parent",
     "Teacher": "Enseignant",
     "zimbra.message.error.attachment": "Une erreur est survenue lors de l'ajout de la pièce jointe, vérifiez la taille de votre mail",
+    "zimbra.message.error.attachment.size": "Le fichier sélectionné ne peut être ajouté en pièce jointe car il dépasse la taille maximale autorisée ({{maxFileSize}} Mo)",
     "zimbra.message.error.attachments": "Une erreur est survenue lors de l'ajout de la pièce jointe",
     "zimbra.message.error.mail.size": "La taille de vos pièces jointes est trop importante, vérifiez la taille de votre mail",
     "zimbra.message.info.iframe": "Le mail contient un code HTML qui n'est pas interprété, vous ne pourrez pas l'envoyer (iframe)",

--- a/zimbra/src/main/resources/public/ts/model/constantes/codeZimbra.ts
+++ b/zimbra/src/main/resources/public/ts/model/constantes/codeZimbra.ts
@@ -4,6 +4,8 @@ export enum SERVICE {
 }
 
 export enum MAIL {
+    INVALID_REQUEST = "mail.INVALID_REQUEST",
+    ATTACHMENT_TOO_BIG = "mail.ATTACHMENT_TOO_BIG",
     MESSAGE_TOO_BIG = "mail.MESSAGE_TOO_BIG"
 }
 

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -37,9 +37,16 @@ import {MAIL, SERVICE, QUOTA} from "./constantes";
 import {AxiosError, AxiosResponse} from "axios";
 import {attachmentService} from "../services";
 
+export enum AttachmentUploadStatus {
+    LOADING = "loading",
+    LOADED = "loaded",
+    FAILED = "failed",
+    ABORT = "abort",
+}
+
 export class Attachment {
     file: File;
-    uploadStatus: string;
+    uploadStatus: AttachmentUploadStatus;
     id: string;
     filename: string;
     size: number;
@@ -47,12 +54,13 @@ export class Attachment {
 
     constructor(file: any) {
         this.file = file;
-        this.uploadStatus = "loading";
+        this.uploadStatus = AttachmentUploadStatus.LOADING;
         this.filename = file.metadata ? file.metadata.filename : file.name;
         this.size = file.metadata ? file.metadata.size : file.size;
         this.id = file._id;
     }
 }
+
 export class Mail implements Selectable {
     id: string;
     date: string;
@@ -324,7 +332,7 @@ export class Mail implements Selectable {
             data.to = _.pluck(this.to, "id");
             data.cc = _.pluck(this.cc, "id");
             data.bcc = _.pluck(this.bcc, "id");
-            data.attachments = this.attachments;
+            data.attachments = this.attachments.filter((attachment: Attachment) => attachment.uploadStatus !== AttachmentUploadStatus.LOADING);
 
             var path = "/zimbra/draft";
             if (this.id) {
@@ -402,9 +410,9 @@ export class Mail implements Selectable {
         }
         let response = await http.get("/zimbra/message/" + this.id);
 
-        response.data.attachments.map(attachment => {
+        response.data.attachments.forEach(attachment => {
             attachment.filename = decodeURI((attachment.filename));
-        })
+        });
 
         Mix.extend(this, response.data);
         this.to = this.to.map(user =>
@@ -481,27 +489,33 @@ export class Mail implements Selectable {
         await Zimbra.instance.folders.draft.mails.refresh();
     }
 
-    async postAttachments(attachmentToUpload : Attachment, workspace : boolean) : Promise<void> {
+    async postAttachments(attachmentToUpload: Attachment, workspace: boolean): Promise<void> {
             let post : Promise<AxiosResponse>;
             if (workspace) {
                 post = attachmentService.postAttachmentFromWorkspace(attachmentToUpload, this);
             } else {
-                post = attachmentService.postAttachmentFromComputer(attachmentToUpload, this)
+                post = attachmentService.postAttachmentFromComputer(attachmentToUpload, this);
             }
             const promise: Promise<void> = post
                 .then((response: AxiosResponse) => {
                     const attachmentWaiting : Attachment[] =
-                        this.attachments.filter((attachment : Attachment) =>
-                            attachment.uploadStatus && attachment.uploadStatus == "loading" && attachment != attachmentToUpload);
+                        this.attachments.filter((attachment: Attachment) =>
+                            attachment.uploadStatus && attachment.uploadStatus == AttachmentUploadStatus.LOADING && attachment != attachmentToUpload);
                     this.attachments = response.data.attachments as Attachment[];
                     this.attachments.forEach((attach: Attachment) => {
                         attach.filename = decodeURI(attach.filename);
-                        attach.uploadStatus = "loaded";
+                        attach.uploadStatus = AttachmentUploadStatus.LOADED;
                     });
                     this.attachments = this.attachments.concat(attachmentWaiting);
                 })
                 .catch((e: AxiosError) => {
-                    sendNotificationErrorZimbra(e.response.data.error);
+                    // remove attachment
+                    this.attachments = this.attachments.filter((attachment: Attachment) => {
+                        return attachment.filename !== attachmentToUpload.filename
+                    });
+                    if (e.response && e.response.data && e.response.data.error) {
+                        sendNotificationErrorZimbra(e.response.data.error);
+                    }
                 });
             await Promise.resolve(promise);
     }
@@ -519,9 +533,9 @@ export class Mail implements Selectable {
     async deleteAttachment(attachment) {
         this.attachments.splice(this.attachments.indexOf(attachment), 1);
         const response = await attachmentService.deleteAttachment(attachment, this);
-        this.attachments = response.data.attachments;
-        this.attachments.map(attachment => {
+        this.attachments = response.data.attachments.map(attachment => {
             attachment.filename = decodeURI(attachment.filename);
+            return attachment;
         })
     }
 
@@ -574,6 +588,9 @@ export class Mails {
     }
 
     addRange(arr: Mail[], selectAll: boolean) {
+        if (!arr.length) {
+            return;
+        }
         if (!(arr[0] instanceof Mail)) {
             arr.forEach(d => {
                 var m = Mix.castAs(Mail, d);
@@ -781,9 +798,14 @@ export const sendNotificationErrorZimbra = (errorReturnByZimbra: string): void =
     //TODO extraire la gestion d'erreur du mail
     try {
         console.error("Zimbra returning : ", errorReturnByZimbra);
-        switch (JSON.parse(errorReturnByZimbra).code) {
+        const zimbraError = JSON.parse(errorReturnByZimbra);
+        switch (zimbraError.code) {
             case SERVICE.INVALID_REQUEST:
+            case MAIL.INVALID_REQUEST:
                 notify.error(lang.translate("zimbra.message.error.attachment"));
+                break;
+            case MAIL.ATTACHMENT_TOO_BIG:
+                notify.error(lang.translate("zimbra.message.error.attachment.size").replace("{{maxFileSize}}", zimbraError.maxFileSize));
                 break;
             case MAIL.MESSAGE_TOO_BIG:
                 notify.info(lang.translate("zimbra.message.error.mail.size"));
@@ -792,7 +814,7 @@ export const sendNotificationErrorZimbra = (errorReturnByZimbra: string): void =
                 notify.error(lang.translate("zimbra.quota.info.warning"));
                 break;
             default:
-                notify.error(lang.translate("zimbra.default.intern.error" + errorReturnByZimbra));
+                notify.error(lang.translate("zimbra.default.intern.error") + zimbraError.code);
 
         }
     } catch (error) {

--- a/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/AttachmentServiceTest.java
+++ b/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/AttachmentServiceTest.java
@@ -1,0 +1,148 @@
+package fr.openent.zimbra.service.test.impl;
+
+import fr.openent.zimbra.Zimbra;
+import fr.openent.zimbra.core.constants.Field;
+import fr.openent.zimbra.helper.ConfigManager;
+import fr.openent.zimbra.helper.HttpClientHelper;
+import fr.openent.zimbra.service.data.SoapZimbraService;
+import fr.openent.zimbra.service.impl.AttachmentService;
+import fr.openent.zimbra.service.impl.MessageService;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.user.UserInfos;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(VertxUnitRunner.class)
+@PrepareForTest({HttpClientHelper.class, Zimbra.class})
+public class AttachmentServiceTest {
+
+    private Vertx vertx;
+    private AttachmentService attachmentService;
+    private SoapZimbraService soapZimbraService;
+    private MessageService messageService;
+    private HttpClient httpClient;
+
+    @Before
+    public void setUp() throws IllegalAccessException {
+        this.vertx = Mockito.spy(Vertx.vertx());
+        this.soapZimbraService = mock(SoapZimbraService.class);
+        this.messageService = mock(MessageService.class);
+        this.attachmentService = new AttachmentService(soapZimbraService, messageService, Vertx.vertx(), new JsonObject(), null);
+
+        this.httpClient = Mockito.mock(HttpClient.class);
+        mockStatic(HttpClientHelper.class);
+        PowerMockito.when(HttpClientHelper.createHttpClient(Mockito.any())).thenReturn(this.httpClient);
+
+        ConfigManager configManager = mock(ConfigManager.class);
+        mockStatic(Zimbra.class);
+        PowerMockito.field(Zimbra.class, "appConfig").set(Zimbra.class, configManager);
+        PowerMockito.when(Zimbra.appConfig.getZimbraFileUploadMaxSize()).thenReturn(20);
+    }
+
+    @Test
+    public void testAddAttachmentBuffer_too_big(TestContext ctx) {
+        Async async = ctx.async();
+
+        String messageId = "1";
+        UserInfos userInfos = new UserInfos();
+
+        HttpServerRequest httpServerRequest = mock(HttpServerRequest.class);
+        HttpClientRequest httpClientRequest = mock(HttpClientRequest.class);
+        HttpClientResponse httpClientResponse = mock(HttpClientResponse.class);
+        Buffer buffer = mock(Buffer.class);
+        Mockito.when(buffer.toString()).thenReturn("413,null\n");
+
+        Mockito.doAnswer(invocation -> {
+            Handler<Either<String, JsonObject>> response = invocation.getArgument(1);
+            response.handle(new Either.Right<>(new JsonObject().put(Field.AUTH_TOKEN, "token")));
+            return null;
+        }).when(soapZimbraService).getUserAuthToken(Mockito.any(), Mockito.any());
+
+        Mockito.doReturn(200).when(httpClientResponse).statusCode();
+        Mockito.doAnswer(invocation -> {
+            Handler<HttpClientResponse> response = invocation.getArgument(1);
+            response.handle(httpClientResponse);
+            return httpClientRequest;
+        }).when(httpClient).postAbs(Mockito.anyString(), Mockito.any());
+        Mockito.doAnswer(invocation -> httpClientRequest).when(httpClientRequest).setChunked(true);
+        Mockito.doAnswer(invocation -> httpClientRequest).when(httpClientRequest).putHeader(Mockito.anyString(), Mockito.anyString());
+
+        Mockito.doAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(buffer);
+            return null;
+        }).when(httpClientResponse).bodyHandler(Mockito.any());
+
+        this.attachmentService.addAttachmentBuffer(messageId, userInfos, httpServerRequest, result -> {
+            String expected = "{\"code\":\"mail.ATTACHMENT_TOO_BIG\",\"maxFileSize\":20}";
+            ctx.assertEquals(expected, result.left().getValue());
+            async.complete();
+        });
+
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testAddAttachmentBuffer_invalid_request(TestContext ctx) {
+        Async async = ctx.async();
+
+        String messageId = "1";
+        UserInfos userInfos = new UserInfos();
+
+        HttpServerRequest httpServerRequest = mock(HttpServerRequest.class);
+        HttpClientRequest httpClientRequest = mock(HttpClientRequest.class);
+        HttpClientResponse httpClientResponse = mock(HttpClientResponse.class);
+        Buffer buffer = mock(Buffer.class);
+        Mockito.when(buffer.toString()).thenReturn("400,null\n");
+
+        Mockito.doAnswer(invocation -> {
+            Handler<Either<String, JsonObject>> response = invocation.getArgument(1);
+            response.handle(new Either.Right<>(new JsonObject().put(Field.AUTH_TOKEN, "token")));
+            return null;
+        }).when(soapZimbraService).getUserAuthToken(Mockito.any(), Mockito.any());
+
+        Mockito.doReturn(200).when(httpClientResponse).statusCode();
+        Mockito.doAnswer(invocation -> {
+            Handler<HttpClientResponse> response = invocation.getArgument(1);
+            response.handle(httpClientResponse);
+            return httpClientRequest;
+        }).when(httpClient).postAbs(Mockito.anyString(), Mockito.any());
+        Mockito.doAnswer(invocation -> httpClientRequest).when(httpClientRequest).setChunked(true);
+        Mockito.doAnswer(invocation -> httpClientRequest).when(httpClientRequest).putHeader(Mockito.anyString(), Mockito.anyString());
+
+        Mockito.doAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(buffer);
+            return null;
+        }).when(httpClientResponse).bodyHandler(Mockito.any());
+
+        this.attachmentService.addAttachmentBuffer(messageId, userInfos, httpServerRequest, result -> {
+            String expected = "{\"code\":\"mail.INVALID_REQUEST\"}";
+            ctx.assertEquals(expected, result.left().getValue());
+            async.complete();
+        });
+
+        async.awaitSuccess(10000);
+    }
+}


### PR DESCRIPTION
## Describe your changes

1. Handle too big attachment:
- Display message
- Remove attachment from attachments list

2. Send only uploaded attachment
3. Add conf "zimbra-file-upload-max-size": 20 to conf.properties

## Checklist tests

1. Try to upload an attachement larger than 20Mo
2. Must display: i18n#zimbra.message.error.attachment.size

## Issue ticket number and link

[#MZI-11](https://jira.support-ent.fr/browse/MZI-11)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)