### PR TITLE
fix(recall) : #MZI-130 recall mail button is now hidden if receivers are not ent users

### DIFF
--- a/zimbra/src/main/resources/i18n/en.json
+++ b/zimbra/src/main/resources/i18n/en.json
@@ -132,5 +132,6 @@
     "yesterday": "Hier",
     "you.answered": "You answered to this message",
     "zimbra.outside.donotchange": "External Mail [Do Not Change]",
-  "account.myaccount": "My account"
+    "zimbra.external.user": "Only mails sended to internal ENT users will be recalled",
+    "account.myaccount": "My account"
 }

--- a/zimbra/src/main/resources/i18n/fr.json
+++ b/zimbra/src/main/resources/i18n/fr.json
@@ -223,5 +223,6 @@
     "zimbra.quota.info.message": "Votre boîte aux lettres est presque pleine. Réduisez la taille de votre boîte aux lettres en supprimant de cette dernière les éléments superflus et en vidant le dossier Corbeille.",
     "zimbra.quota.info.warning": "Votre boîte aux lettres est pleine. Votre boîte aux lettres ne peut plus envoyer de messages. Réduisez sa taille. Supprimez de votre boîte aux lettres les éléments superflus et videz votre dossier Corbeille.",
     "zimbra.default.intern.error": "Erreur interne: ",
+    "zimbra.external.user": "Seuls les mails adressés aux destinataires internes á l'ENT seront rappelés",
     "zimbra.share.search.help": "Ex : Sabine, Dupont, Enseignants..."
 }

--- a/zimbra/src/main/resources/public/template/folders-templates/toaster.html
+++ b/zimbra/src/main/resources/public/template/folders-templates/toaster.html
@@ -27,8 +27,8 @@
                 <button ng-click="moveSelection()" ng-if="zimbra.currentFolder.mails.selection.length && zimbra.currentFolder.folderName !== 'trash'">
                 <i18n>move.inside.folder</i18n>
             </button>
-            <button ng-click="returnSelection()"
-                    ng-if="isReturnable()"
+            <button ng-click="toggleRecallView()"
+                    ng-if="isRecallable()"
                     workflow="zimbra.return" >
                 <i18n>return</i18n>
             </button>

--- a/zimbra/src/main/resources/public/template/folders-templates/toaster.html
+++ b/zimbra/src/main/resources/public/template/folders-templates/toaster.html
@@ -28,9 +28,7 @@
                 <i18n>move.inside.folder</i18n>
             </button>
             <button ng-click="returnSelection()"
-                    ng-if="zimbra.currentFolder.mails.selection.selectedElements.length < 2 &&
-                    zimbra.currentFolder.mails.selection.selectedElements[0].returned == 'NONE' &&
-                    zimbra.currentFolder.folderName === 'outbox'"
+                    ng-if="isReturnable()"
                     workflow="zimbra.return" >
                 <i18n>return</i18n>
             </button>

--- a/zimbra/src/main/resources/public/template/folders-templates/toaster.html
+++ b/zimbra/src/main/resources/public/template/folders-templates/toaster.html
@@ -28,7 +28,7 @@
                 <i18n>move.inside.folder</i18n>
             </button>
             <button ng-click="toggleRecallView()"
-                    ng-if="isRecallable()"
+                    ng-if="isSelectedRecallable() && zimbra.currentFolder.folderName === 'outbox'"
                     workflow="zimbra.return" >
                 <i18n>return</i18n>
             </button>

--- a/zimbra/src/main/resources/public/template/mail-actions/view-mail.html
+++ b/zimbra/src/main/resources/public/template/mail-actions/view-mail.html
@@ -24,7 +24,7 @@
 				<button ng-click="replyAll()" ng-disabled="!mail.allowReplyAll"><i18n>replyall</i18n></button>
 				<a class="button"   target="_blank" ng-href="/zimbra/print#/printMail/[[mail.id]]"><i18n>print</i18n></a>
 				<button ng-click="mail.remove(); openFolder()"><i18n>remove</i18n></button>
-				<button ng-click="returnSelection()" ng-if="mail.returned == 'NONE'">
+				<button ng-click="toggleRecallView()" ng-if="isRecallable(mail)">
 					<i18n>return</i18n>
 				</button>
 			</plus>

--- a/zimbra/src/main/resources/public/template/recall-mail.html
+++ b/zimbra/src/main/resources/public/template/recall-mail.html
@@ -16,34 +16,42 @@
   -->
 <div>
     <h2>
-        <i18n>mail.return.title</i18n>
+        <i18n>mailToRecall.return.title</i18n>
     </h2>
 
     <div class="vertical-spacing-twice horizontal-margin-twice">
         <h5>
-            <i18n>mail.return.libelle</i18n>
+            <i18n>mailToRecall.return.libelle</i18n>
         </h5>
-        <ul ng-hide="!!mail">
-            <li class="list-return-mail" ng-repeat="mail in zimbra.currentFolder.mails.selection.selectedElements" >
-                [[mail.subject]]
-            </li>
-        </ul>
-        <ul ng-if="!!mail">
-            <li class="list-return-mail">
-                [[mail.subject]]
-            </li>
-        </ul>
+        <article>
+            <div class="flex-row align-center">
+                <div class="states"  ng-hide="showRightSide()">
+                    <i class="undo" ng-if="mailToRecall.response" tooltip="you.answered"></i>
+                </div>
+                <div class="flex-all-remains horizontal-margin cell-ellipsis">
+					<span class="strong" ng-repeat="receiver in receivers = (allReceivers(mailToRecall) | limitTo:5 | filter: filterUsers(mailToRecall))">
+						<span>[[mailToRecall.map(receiver).displayName]]</span><span ng-if="$index < (receivers.length - 1) && receivers.length > 1">, </span>
+					</span>
+                    <br>
+                    <span class="small-text">[[mailToRecall.subject]]</span>
+                    <div class="notification-date">
+                        <em class="low-importance right-magnet">[[mailToRecall.notifDate()]]</em>
+                    </div>
+                </div>
+            </div>
+
+
+        </article>
     </div>
 
     <div class="vertical-spacing-twice horizontal-margin-twice">
         <h5>
-            <i18n>mail.return.comment</i18n>
+            <i18n>mailToRecall.return.comment</i18n>
         </h5>
         <textarea ng-model="comment"></textarea>
     </div>
 
-    <input type="submit" class="right-magnet" ng-hide="!!mail" i18n-value="validate" ng-click="returnMail(zimbra.currentFolder.mails.selection.selectedElements[0].id, comment)"/>
-    <input type="submit" class="right-magnet" ng-if="!!mail" i18n-value="validate" ng-click="returnMail(mail.id, comment)"/>
+    <input type="submit" class="right-magnet" i18n-value="validate" ng-click="recallMail(mailToRecall.id, comment)"/>
     <input type="button" class="right-magnet cancel button" i18n-value="cancel"
            ng-click="lightbox.show = false; template.close('lightbox')"/>
 </div>

--- a/zimbra/src/main/resources/public/template/recall-mail.html
+++ b/zimbra/src/main/resources/public/template/recall-mail.html
@@ -16,13 +16,14 @@
   -->
 <div>
     <h2>
-        <i18n>mailToRecall.return.title</i18n>
+        <i18n>mail.return.title</i18n>
     </h2>
 
     <div class="vertical-spacing-twice horizontal-margin-twice">
         <h5>
-            <i18n>mailToRecall.return.libelle</i18n>
+            <i18n>mail.return.libelle</i18n>
         </h5>
+
         <article>
             <div class="flex-row align-center">
                 <div class="states"  ng-hide="showRightSide()">
@@ -39,14 +40,13 @@
                     </div>
                 </div>
             </div>
-
-
         </article>
+        <span ng-show="containsExternal(mailToRecall.to)">&#9888; <i18n>zimbra.external.user</i18n></span>
     </div>
 
     <div class="vertical-spacing-twice horizontal-margin-twice">
         <h5>
-            <i18n>mailToRecall.return.comment</i18n>
+            <i18n>mail.return.comment</i18n>
         </h5>
         <textarea ng-model="comment"></textarea>
     </div>

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -779,17 +779,26 @@ export let zimbraController = ng.controller("ZimbraController", [
             }
             return false;
         }
+        $scope.containsExternal = function(mails: string[]): boolean {
+            for (let mail of mails) {
+                if (mail.includes("@")){
+                    return true;
+                }
+            }
+            return false;
+        }
         $scope.getCurrentRecall = function(): Mail {
             if ($scope.zimbra.currentFolder.mails.selection.selectedElements.length > 0)
                 return $scope.zimbra.currentFolder.mails.selection.selectedElements[0]
-            return null;
+            return $scope.mail;
         }
-
-        $scope.isRecallable = function(): boolean {
+        $scope.isSelectedRecallable = function(): boolean {
             return $scope.zimbra.currentFolder.mails.selection.selectedElements.length == 1 &&
-                $scope.zimbra.currentFolder.mails.selection.selectedElements[0].recalled == 'NONE' &&
-                $scope.zimbra.currentFolder.folderName === 'outbox' &&
-                $scope.containsInternal($scope.zimbra.currentFolder.mails.selection.selectedElements[0].to);
+                $scope.isRecallable($scope.zimbra.currentFolder.mails.selection.selectedElements[0]);
+        }
+        $scope.isRecallable = function(mail: Mail): boolean {
+            return mail.returned == 'NONE' &&
+                $scope.containsInternal(<any>mail.to);
         }
 
         $scope.toggleRecallView = function() {

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -779,17 +779,23 @@ export let zimbraController = ng.controller("ZimbraController", [
             }
             return false;
         }
-        $scope.isReturnable = function(): boolean {
-            return $scope.zimbra.currentFolder.mails.selection.selectedElements.length < 2 &&
-                $scope.zimbra.currentFolder.mails.selection.selectedElements[0].returned == 'NONE' &&
-                $scope.zimbra.currentFolder.folderName === 'outbox' &&
-                $scope.containsInternal($scope.zimbra.currentFolder.mails.selection.selectedElements[0].to);
-
+        $scope.getCurrentRecall = function(): Mail {
+            if ($scope.zimbra.currentFolder.mails.selection.selectedElements.length > 0)
+                return $scope.zimbra.currentFolder.mails.selection.selectedElements[0]
+            return null;
         }
 
-        $scope.returnSelection = function() {
+        $scope.isRecallable = function(): boolean {
+            return $scope.zimbra.currentFolder.mails.selection.selectedElements.length == 1 &&
+                $scope.zimbra.currentFolder.mails.selection.selectedElements[0].recalled == 'NONE' &&
+                $scope.zimbra.currentFolder.folderName === 'outbox' &&
+                $scope.containsInternal($scope.zimbra.currentFolder.mails.selection.selectedElements[0].to);
+        }
+
+        $scope.toggleRecallView = function() {
             $scope.lightbox.show = true;
-            template.open("lightbox", "return-mail");
+            $scope.mailToRecall = $scope.getCurrentRecall();
+            template.open("lightbox", "recall-mail");
         };
 
         $scope.moveToFolderClick = async (folder, obj) => {
@@ -807,7 +813,7 @@ export let zimbraController = ng.controller("ZimbraController", [
             }, 10);
         };
 
-        $scope.returnMail = async (id, comment) => {
+        $scope.recallMail = async (id, comment) => {
             $scope.lightbox.show = false;
             template.close("lightbox");
             var data: any = {id: id, comment: comment};

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -797,7 +797,7 @@ export let zimbraController = ng.controller("ZimbraController", [
                 $scope.isRecallable($scope.zimbra.currentFolder.mails.selection.selectedElements[0]);
         }
         $scope.isRecallable = function(mail: Mail): boolean {
-            return mail.returned == 'NONE' &&
+            return mail.returned === 'NONE' &&
                 $scope.containsInternal(<any>mail.to);
         }
 
@@ -822,7 +822,7 @@ export let zimbraController = ng.controller("ZimbraController", [
             }, 10);
         };
 
-        $scope.recallMail = async (id, comment) => {
+        $scope.recallMail = async (id: string, comment: string) => {
             $scope.lightbox.show = false;
             template.close("lightbox");
             var data: any = {id: id, comment: comment};

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -771,6 +771,21 @@ export let zimbraController = ng.controller("ZimbraController", [
             $scope.lightbox.show = true;
             template.open("lightbox", "move-mail");
         };
+        $scope.containsInternal = function(mails: string[]): boolean {
+            for (let mail of mails) {
+                if (!mail.includes("@")){
+                    return true;
+                }
+            }
+            return false;
+        }
+        $scope.isReturnable = function(): boolean {
+            return $scope.zimbra.currentFolder.mails.selection.selectedElements.length < 2 &&
+                $scope.zimbra.currentFolder.mails.selection.selectedElements[0].returned == 'NONE' &&
+                $scope.zimbra.currentFolder.folderName === 'outbox' &&
+                $scope.containsInternal($scope.zimbra.currentFolder.mails.selection.selectedElements[0].to);
+
+        }
 
         $scope.returnSelection = function() {
             $scope.lightbox.show = true;

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -85,7 +85,7 @@ export class Mail implements Selectable {
     selected: boolean;
     allowReply: boolean;
     allowReplyAll: boolean;
-    returned: string;
+    recalled: string;
 
     constructor(id?: string) {
         this.id = id;
@@ -93,7 +93,7 @@ export class Mail implements Selectable {
         this.attachments = [];
         this.allowReply = true;
         this.allowReplyAll = true;
-        this.returned = "NONE";
+        this.recalled = "NONE";
     }
 
     isUserAuthor(): boolean {

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -85,7 +85,7 @@ export class Mail implements Selectable {
     selected: boolean;
     allowReply: boolean;
     allowReplyAll: boolean;
-    recalled: string;
+    returned: string;
 
     constructor(id?: string) {
         this.id = id;
@@ -93,7 +93,7 @@ export class Mail implements Selectable {
         this.attachments = [];
         this.allowReply = true;
         this.allowReplyAll = true;
-        this.recalled = "NONE";
+        this.returned = "NONE";
     }
 
     isUserAuthor(): boolean {


### PR DESCRIPTION
## Describe your changes
Toaster does not display anymore the recall option if all the mail receivers are not users of ENT. The button will now be displayed only if at least on of the receiver is an ENT user.
Also refactored some method and attribute to swith from "returned" to "recall".
## Checklist tests
- [x] Open the toaster with mail sended to at least one ENT user -> see the button
- [x] Open the toaster with mail sended to external email  -> button hidden
## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)