### PR TITLE
fix: #MZI-109 encode folder path for uri, fix npe when folder does not exist

### DIFF
--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -506,10 +506,16 @@ public class ZimbraController extends BaseController {
                     b = Boolean.parseBoolean(unread);
                 }
                 messageService.listMessages(folder, b, user, page, search, event -> {
-                    if (!folder.equals("/Sent")) {
+                    if (folder.equals("/Sent")) {
+                        returnedMailService.renderReturnedMail(request, user, event);
+                        return;
+                    }
+
+                    if (event.isRight()) {
                         renderJson(request, event.right().getValue());
                     } else {
-                        returnedMailService.renderReturnedMail(request, user, event);
+                        log.error(String.format("[Zimbra@ZimbraController::listMessages] failed to listMessages: %s", event.left().getValue()));
+                        badRequest(request);
                     }
                 });
             } else {

--- a/zimbra/src/main/resources/public/ts/model/folder.ts
+++ b/zimbra/src/main/resources/public/ts/model/folder.ts
@@ -133,7 +133,7 @@ export class Trash extends SystemFolder {
 
     constructor({unread, count, folders, path}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "trash";
@@ -217,7 +217,7 @@ export class Trash extends SystemFolder {
 export class Inbox extends SystemFolder {
     constructor({unread, count, folders, path}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "inbox";
@@ -249,7 +249,7 @@ export class Draft extends SystemFolder {
 
     constructor({unread, count, folders, path}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "draft";
@@ -302,7 +302,7 @@ export class Draft extends SystemFolder {
 export class Outbox extends SystemFolder {
     constructor({unread, count, folders, path}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "outbox";
@@ -333,7 +333,7 @@ export class Outbox extends SystemFolder {
 export class Spams extends SystemFolder {
     constructor({unread, count, folders, path, id}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "spams";
@@ -464,7 +464,7 @@ export class UserFolders {
     constructor(folders) {
         this.all = [];
         folders.forEach(folder => {
-            const f = new UserFolder({get: `/zimbra/list?folder=${folder.path}`}, folder);
+            const f = new UserFolder({get: `/zimbra/list?folder=${encodeURIComponent(folder.path)}`}, folder);
             f.name = folder.folderName;
             f.id = folder.id;
             f.path = folder.path;

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -651,7 +651,7 @@ export class Mails {
         }
         const response = await http.get(
             "/zimbra/list?folder=" +
-            this.userFolder.path +
+            encodeURIComponent(this.userFolder.path) +
             "&restrain=&page=" +
             data.pageNumber +
             "&unread=" +

--- a/zimbra/src/main/resources/public/ts/model/zimbra.ts
+++ b/zimbra/src/main/resources/public/ts/model/zimbra.ts
@@ -118,7 +118,7 @@ export class Zimbra {
                 const parentPath = newFolder.path.replace(`/${newFolder.folderName}`, '');
                 const parentFolder = window.folderMap.get(parentPath.trim() !== '' ? parentPath : '/Inbox');
                 if (parentFolder) {
-                    const f = new UserFolder({get: `/zimbra/list?folder=${newFolder.path}`}, newFolder);
+                    const f = new UserFolder({get: `/zimbra/list?folder=${encodeURIComponent(newFolder.path)}`}, newFolder);
                     if (parentFolder.path === '/Inbox') this.userFolders.all.push(f);
                     else parentFolder.userFolders.all.push(f);
                     f.name = newFolder.folderName;


### PR DESCRIPTION
## Describe your changes

* Encode the folder paths for uri with `encodeURIComponent`
* Fix NPE when folder does not exist (GET /zimbra/list)

## Checklist tests

Front:
1. Create folder with special character (ex: t#est)
2. Open folder

Back:
1. Test GET/zimbra/list?folder=/Inbox/invalidpath => returns 400 instead of a pending request

## Issue ticket number and link

[#MZI-109](https://jira.support-ent.fr/browse/MZI-109)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)