### PR TITLE
fix: #MZI-132 prevent sql error when vertx starts

### DIFF
--- a/zimbra/src/main/java/fr/openent/zimbra/service/data/SqlDbMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/data/SqlDbMailService.java
@@ -332,12 +332,16 @@ public class SqlDbMailService extends DbMailService {
      * @param ids List of returnedMail ids
      */
     public void getMailReturnedByIds(List<String> ids, Handler<Either<String, JsonArray>> handler) {
+        if (ids.isEmpty()) {
+            handler.handle(new Either.Right<>(new JsonArray()));
+            return;
+        }
         String query = "SELECT *" +
                 " FROM " + this.returnedMailTable +
                 " WHERE id IN " + Sql.listPrepared(ids);
         JsonArray params = new fr.wseduc.webutils.collections.JsonArray();
-        for (int i = 0; i < ids.size(); i++) {
-            params.add(Integer.parseInt(ids.get(i)));
+        for (String id : ids) {
+            params.add(Integer.parseInt(id));
         }
         sql.prepared(query, params, SqlResult.validResultHandler(handler));
     }
@@ -349,13 +353,17 @@ public class SqlDbMailService extends DbMailService {
      * @param user_id Id of the user
      */
     public void getMailReturnedByMailsIdsAndUser(List<String> ids, String user_id, Handler<Either<String, JsonArray>> handler) {
+        if (ids.isEmpty()) {
+            handler.handle(new Either.Right<>(new JsonArray()));
+            return;
+        }
         String query = "SELECT *" +
                 " FROM " + this.returnedMailTable +
                 " WHERE user_id = ? AND mail_id IN " + Sql.listPrepared(ids);
         JsonArray params = new fr.wseduc.webutils.collections.JsonArray();
         params.add(user_id);
-        for (int i = 0; i < ids.size(); i++) {
-            params.add(ids.get(i));
+        for (String id : ids) {
+            params.add(id);
         }
         sql.prepared(query, params, SqlResult.validResultHandler(handler));
     }

--- a/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/SqlDbMailServiceTest.java
+++ b/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/SqlDbMailServiceTest.java
@@ -1,0 +1,75 @@
+package fr.openent.zimbra.service.test.impl;
+
+import fr.openent.zimbra.service.data.SqlDbMailService;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.sql.Sql;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(VertxUnitRunner.class)
+@PrepareForTest({Sql.class})
+public class SqlDbMailServiceTest {
+
+    private SqlDbMailService sqlDbMailService;
+    private final Sql sql = PowerMockito.mock(Sql.class);
+
+    @Before
+    public void setUp() throws NoSuchFieldException {
+        this.sqlDbMailService = new SqlDbMailService("test");
+        FieldSetter.setField(sqlDbMailService, sqlDbMailService.getClass().getDeclaredField("sql"), sql);
+        FieldSetter.setField(sqlDbMailService, sqlDbMailService.getClass().getDeclaredField("returnedMailTable"), "schema.mail_returned");
+    }
+
+    @Test
+    public void testGetMailReturnedByIds_empty_ids(TestContext ctx) {
+        List<String> emptyList = new ArrayList<>();
+        Async async = ctx.async();
+
+        this.sqlDbMailService.getMailReturnedByIds(emptyList, result -> {
+            JsonArray expected = new JsonArray();
+            ctx.assertEquals(expected, result.right().getValue());
+            async.complete();
+        });
+
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testGetMailReturnedByIds_not_empty(TestContext ctx) {
+        Async async = ctx.async();
+        List<String> userIds = new ArrayList<>();
+        userIds.add("1");
+        String expectedQuery = "SELECT * FROM schema.mail_returned WHERE id IN (?)";
+        JsonArray expectedParams = new JsonArray().add(1);
+
+        Mockito.doAnswer((Answer<Void>) invocation -> {
+            String queryResult = invocation.getArgument(0);
+            JsonArray paramsResult = invocation.getArgument(1);
+            ctx.assertEquals(expectedQuery, queryResult);
+            ctx.assertEquals(expectedParams.toString(), paramsResult.toString());
+            async.complete();
+            return null;
+        }).when(sql).prepared(Mockito.anyString(), Mockito.any(JsonArray.class), Mockito.any(Handler.class));
+
+        this.sqlDbMailService.getMailReturnedByIds(userIds, null);
+
+        async.awaitSuccess(10000);
+    }
+}


### PR DESCRIPTION
## Describe your changes

Prevent sql error when vertx starts

## Checklist tests

## Issue ticket number and link

[JIRA#MZI-132](https://jira.support-ent.fr/browse/MZI-132)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)