### PR TITLE
fix(restore): #MZI-98 move from trash to any other folder is now possible

### DIFF
--- a/zimbra/src/main/resources/i18n/en.json
+++ b/zimbra/src/main/resources/i18n/en.json
@@ -71,7 +71,7 @@
     "mail-in": "Message de la boîte de réception",
     "mail-new": "Message brouillon",
     "mail-out": "Message de la boîte d'envoi",
-    "mail.move": "Déplacer le(s) message(s)",
+    "mail.move": "Move mails to",
     "mail.sent": "Mail sent",
     "me": "Me",
     "message": "message",
@@ -79,7 +79,7 @@
     "ml.sent": "Message envoyé",
     "modify": "Modifier",
     "move": "move",
-    "move.first.caps": "Déplacer",
+    "move.first.caps": "Move",
     "move.inside.folder": "Déplacer dans un dossier",
     "name": "Nom",
     "new.message": "New message",
@@ -133,5 +133,7 @@
     "you.answered": "You answered to this message",
     "zimbra.outside.donotchange": "External Mail [Do Not Change]",
     "zimbra.external.user": "Only mails sended to internal ENT users will be recalled",
-    "account.myaccount": "My account"
+    "account.myaccount": "My account",
+    "message.folder": "Messages folders",
+    "personal.folder": "Personal folders"
 }

--- a/zimbra/src/main/resources/i18n/fr.json
+++ b/zimbra/src/main/resources/i18n/fr.json
@@ -87,7 +87,7 @@
     "mail-in": "Message de la boîte de réception",
     "mail-new": "Message brouillon",
     "mail-out": "Message de la boîte d'envoi",
-    "mail.move": "Déplacer le(s) message(s)",
+    "mail.move": "Déplacer le(s) message(s) vers",
     "mail.sent": "Message envoyé",
     "me": "Moi",
     "message": "le message",
@@ -225,5 +225,7 @@
     "zimbra.quota.info.warning": "Votre boîte aux lettres est pleine. Votre boîte aux lettres ne peut plus envoyer de messages. Réduisez sa taille. Supprimez de votre boîte aux lettres les éléments superflus et videz votre dossier Corbeille.",
     "zimbra.default.intern.error": "Erreur interne: ",
     "zimbra.external.user": "Seuls les mails adressés aux destinataires internes á l'ENT seront rappelés",
-    "zimbra.share.search.help": "Ex : Sabine, Dupont, Enseignants..."
+    "zimbra.share.search.help": "Ex : Sabine, Dupont, Enseignants...",
+    "message.folder": "Dossiers de messagerie",
+    "personal.folder": "Dossiers personnels"
 }

--- a/zimbra/src/main/resources/public/template/folders-templates/toaster.html
+++ b/zimbra/src/main/resources/public/template/folders-templates/toaster.html
@@ -21,19 +21,16 @@
             <button ng-click="showConfirm()" ng-if="zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length">
                 <i18n>remove</i18n>
             </button>
-            <button ng-click="restore()" ng-if="(zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length) && zimbra.currentFolder.folderName === 'trash'">
-                <i18n>restore</i18n>
+            <button ng-click="moveSelection()" ng-if="(zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length) && (zimbra.currentFolder.folderName === 'trash' || userFolders.all.includes(zimbra.currentFolder))">
+                <i18n>move.first.caps</i18n>
             </button>
-                <button ng-click="moveSelection()" ng-if="zimbra.currentFolder.mails.selection.length && zimbra.currentFolder.folderName !== 'trash'">
+                <button ng-click="moveSelection()" ng-if="zimbra.currentFolder.mails.selection.length && folders.list.includes(zimbra.currentFolder) && zimbra.currentFolder.folderName !== 'trash'">
                 <i18n>move.inside.folder</i18n>
             </button>
             <button ng-click="toggleRecallView()"
                     ng-if="isSelectedRecallable() && zimbra.currentFolder.folderName === 'outbox'"
                     workflow="zimbra.return">
                 <i18n>return</i18n>
-            </button>
-            <button ng-click="removeFromUserFolder()" ng-if="zimbra.currentFolder.mails.selection.length && zimbra.currentFolder.id">
-                <i18n>remove.from.folder</i18n>
             </button>
             <button ng-click="toggleUnreadSelection(false, zimbra.currentFolder)" ng-if="
                     zimbra.currentFolder.mails.selection.length && (zimbra.currentFolder.folderName === 'inbox' || zimbra.currentFolder.id) &&

--- a/zimbra/src/main/resources/public/template/move-mail.html
+++ b/zimbra/src/main/resources/public/template/move-mail.html
@@ -16,13 +16,17 @@
   -->
 
  <!-- Folders - move popup templates -->
+
  <script type="text/ng-template" id="move-folders-content">
+
 	 <a ng-click="destination.folder = folder; moveToFolderClick(folder, obj); folder.selected = !folder.selected"
 		 ng-init="obj = { template: '' }"
 		 ng-class="{ selected: destination.folder.id === folder.id, opened: isOpenedFolder(folder)  }"
 		 class="folder-list-item">
 		<i class="arrow" ng-if="folder.userFolders.all.length"></i>
- 		[[folder.name]]
+		<span ng-if="!folders.list.includes(folder)">[[folder.name]]</span>
+		<span ng-if="folders.list.includes(folder)">[[lang.translate(folder.folderName)]]</span>
+
  	</a>
  	<ul ng-class="{ selected: destination.folder.id === folder.id, closed: isClosedFolder(folder) }"
 		 ng-if="isOpenedFolder(folder)">
@@ -32,15 +36,22 @@
  	</ul>
  </script>
  <script type="text/ng-template" id="move-folders-root">
- 	<ul>
- 		<li ng-repeat="folder in userFolders.all" ng-include="'move-folders-content'"></li>
- 	</ul>
+	 <div ng-if="(!folders.list.includes(zimbra.currentFolder) || zimbra.currentFolder.folderName === 'trash')">
+		 <h3><i18n>messages</i18n></h3>
+		 <ul>
+			 <li ng-repeat="folder in folders.list" ng-include="'move-folders-content'" ng-if="zimbra.currentFolder.id != folder.id"></li>
+		 </ul>
+	 </div>
+
+	 <h3><i18n>user.folders</i18n></h3>
+	 <ul>
+		 <li ng-repeat="folder in userFolders.all" ng-include="'move-folders-content'" ng-if="zimbra.currentFolder.id != folder.id"></li>
+	 </ul>
  </script>
 
 <h2><i18n>mail.move</i18n></h2>
 
 <div class="vertical-spacing-twice horizontal-margin-twice">
-    <h4><i18n>destination.folder</i18n></h4>
     <nav class="vertical vertical-spacing-twice horizontal-margin-twice" ng-include="'move-folders-root'"></nav>
 </div>
 

--- a/zimbra/src/main/resources/public/ts/model/folder.ts
+++ b/zimbra/src/main/resources/public/ts/model/folder.ts
@@ -131,7 +131,7 @@ export abstract class SystemFolder extends Folder {
 export class Trash extends SystemFolder {
     userFolders: Selection<UserFolder> = new Selection<UserFolder>([]);
 
-    constructor({unread, count, folders, path}) {
+    constructor({unread, count, folders, path, id}) {
         super({
             get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
@@ -141,6 +141,7 @@ export class Trash extends SystemFolder {
         this.count = count;
         this.folders = folders;
         this.path = path;
+        this.id = id;
     }
 
     selectAll() {
@@ -215,7 +216,7 @@ export class Trash extends SystemFolder {
 }
 
 export class Inbox extends SystemFolder {
-    constructor({unread, count, folders, path}) {
+    constructor({unread, count, folders, path, id}) {
         super({
             get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
@@ -225,6 +226,7 @@ export class Inbox extends SystemFolder {
         this.count = count;
         this.folders = folders;
         this.path = path;
+        this.id = id;
     }
 
     async sync() {
@@ -247,7 +249,7 @@ export class Inbox extends SystemFolder {
 export class Draft extends SystemFolder {
     totalNb: number;
 
-    constructor({unread, count, folders, path}) {
+    constructor({unread, count, folders, path, id}) {
         super({
             get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
@@ -258,6 +260,7 @@ export class Draft extends SystemFolder {
         this.folders = folders;
         this.path = path;
         this.totalNb = count;
+        this.id = id;
     }
 
     selectAll() {
@@ -300,7 +303,7 @@ export class Draft extends SystemFolder {
 }
 
 export class Outbox extends SystemFolder {
-    constructor({unread, count, folders, path}) {
+    constructor({unread, count, folders, path, id}) {
         super({
             get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
@@ -310,6 +313,7 @@ export class Outbox extends SystemFolder {
         this.count = count;
         this.folders = folders;
         this.path = path;
+        this.id = id;
     }
 
     selectAll() {
@@ -513,6 +517,12 @@ export class SystemFolders {
                     break;
             }
         });
+        this.list.push(this.inbox);
+        this.list.push(this.outbox);
+        this.list.push(this.draft);
+        this.list.push(this.trash);
+        this.list.push(this.spams);
+
     }
 
     async openFolder(folderName) {


### PR DESCRIPTION
## Describe your changes
Before this update, restore from trash was sending the mail into inbox folder. Now you can choose where you want to send it. Also remove the "move out from folder" button because now we just have a move button which add differents options depending on current folder.
## Checklist tests
- [x] Move a mail from trash in other folders.
- [x] Move a mail from user folder to any of the others folders
- [x] Move a mail from inbox to trash  
## Issue ticket number and link
[ MZI-98 ]
https://jira.support-ent.fr/browse/MZI-98
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)