### PR TITLE
fix: #MZI-136 fix display names

### DIFF
--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -17,10 +17,11 @@ public class Field {
     public static final String SIZE = "size";
     public static final String APP = "zimbra";
     public static final String FALSE = "false";
-    public static  final String INLINE = "inline";
-    public static  final String HTTPCLIENT = "httpClient";
-    public static  final String ZIMBRARESPONSE = "zimbraResponse";
-    public static  final String UNAUTHORIZED = "unauthorized";
+    public static final String INLINE = "inline";
+    public static final String HTTPCLIENT = "httpClient";
+    public static final String ZIMBRARESPONSE = "zimbraResponse";
+    public static final String USERNAME = "username";
+    public static final String UNAUTHORIZED = "unauthorized";
 
     public static final String MAIL_ATTACHMENT_TOO_BIG = "mail.ATTACHMENT_TOO_BIG";
     public static final String MAIL_INVALID_REQUEST = "mail.INVALID_REQUEST";

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/StringHelper.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/StringHelper.java
@@ -1,6 +1,7 @@
 package fr.openent.zimbra.helper;
 
 import java.util.List;
+import java.util.UUID;
 
 public class StringHelper {
 
@@ -18,5 +19,14 @@ public class StringHelper {
             sep = separator;
         }
         return sb.toString();
+    }
+
+    public static boolean isUUID(String str) {
+        try {
+            UUID.fromString(str);
+            return true;
+        } catch (IllegalArgumentException exception) {
+            return false;
+        }
     }
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/model/message/Message.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/message/Message.java
@@ -118,12 +118,12 @@ public class Message {
     }
 
     private void setFrontFolder() {
-        if(ZimbraFlags.isDraft(zimbraFlags)){
-            frontFolder = "DRAFT";
-        }else if (ZimbraFlags.isSentByMe(zimbraFlags)) {
-            frontFolder = "OUTBOX";
-        }else {
-            frontFolder = "INBOX";
+        if (ZimbraFlags.isDraft(zimbraFlags)) {
+            frontFolder = FrontConstants.FOLDER_DRAFT;
+        } else if (ZimbraFlags.isSentByMe(zimbraFlags)) {
+            frontFolder = FrontConstants.FOLDER_OUTBOX;
+        } else {
+            frontFolder = FrontConstants.FOLDER_INBOX;
         }
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -21,6 +21,7 @@ import fr.openent.zimbra.Zimbra;
 import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.helper.ConfigManager;
 import fr.openent.zimbra.helper.FutureHelper;
+import fr.openent.zimbra.helper.StringHelper;
 import fr.openent.zimbra.model.MailAddress;
 import fr.openent.zimbra.model.ZimbraUser;
 import fr.openent.zimbra.model.constant.FrontConstants;
@@ -44,10 +45,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.user.UserInfos;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -64,6 +62,7 @@ public class MessageService {
     private final DbMailService dbMailService;
     private final UserService userService;
     private final GroupService groupService;
+
     private static final Logger log = LoggerFactory.getLogger(MessageService.class);
 
     public MessageService(SoapZimbraService soapService, FolderService folderService,
@@ -142,6 +141,85 @@ public class MessageService {
     }
 
     /**
+     * Add displayNames to frontMsg response
+     *
+     * @param frontMessages
+     * @return
+     */
+    private Future<Void> addDisplayNames(JsonArray frontMessages) {
+        Promise<Void> promise = Promise.promise();
+
+        List<JsonArray> displayNames = this.getDisplayNames(frontMessages);
+        JsonArray userIds = new JsonArray();
+        displayNames.forEach(displayName -> userIds.add(displayName.getString(0)));
+
+        this.retrieveUsernames(userIds)
+                .onSuccess(usernames -> {
+                    displayNames.forEach(displayName -> {
+                        String username = usernames.get(displayName.getString(0));
+                        displayName.set(1, username);
+                    });
+                    promise.complete();
+                })
+                .onFailure(e -> promise.fail(e.getMessage()));
+
+        return promise.future();
+    }
+
+    /**
+     * Extract displayNames from frontMsg
+     *
+     * @param frontMessages
+     * @return
+     */
+    private List<JsonArray> getDisplayNames(JsonArray frontMessages) {
+        List<JsonArray> response = new ArrayList<>();
+        for (Object obj : frontMessages) {
+            JsonObject mail = (JsonObject) obj;
+            JsonArray displayNames = mail.getJsonArray(FrontConstants.MAIL_DISPLAYNAMES, new JsonArray());
+            for (Object displayName : displayNames) {
+                if (!(displayName instanceof JsonArray) || ((JsonArray) displayName).size() == 0) continue;
+                String userId = ((JsonArray) displayName).getString(0);
+                if (userId != null && StringHelper.isUUID(userId)) {
+                    response.add((JsonArray) displayName);
+                }
+            }
+        }
+        return response;
+    }
+
+    /**
+     * Retrieve username from entcore with JsonArray of userIds
+     *
+     * @param userIds JsonArray of userIds
+     * @return Future of HashMap<String, String>
+     */
+    private Future<HashMap<String, String>> retrieveUsernames(JsonArray userIds) {
+        Promise<HashMap<String, String>> promise = Promise.promise();
+
+        userService.getUsers(userIds, userIds, (response) -> {
+            if (response.isLeft()) {
+                promise.fail(response.left().getValue());
+            } else {
+                List<JsonObject> users = response.right().getValue().getList();
+
+                HashMap<String, String> usernames = new HashMap<>();
+                for (JsonObject user : users) {
+                    String id = user.getString(Field.ID);
+                    String username = user.getString(Field.USERNAME);
+                    if (id != null && username != null) {
+                        usernames.put(id, username);
+                    }
+                }
+
+                promise.complete(usernames);
+            }
+        });
+
+        return promise.future();
+    }
+
+    /**
      * Process recursively a zimbra searchResult and transform it to Front Message
      * Form of Front message returned :
      * {
@@ -171,7 +249,9 @@ public class MessageService {
     private void processSearchResult(JsonArray zimbraMessages, JsonArray frontMessages, Map<String, String> addressMap,
                                      Handler<Either<String, JsonArray>> result) {
         if (zimbraMessages.isEmpty()) {
-            result.handle(new Either.Right<>(frontMessages));
+            this.addDisplayNames(frontMessages)
+                    .onSuccess(res -> result.handle(new Either.Right<>(frontMessages)))
+                    .onFailure(res -> result.handle(new Either.Left<>(res.getMessage())));
             return;
         }
         JsonObject zimbraMsg;
@@ -183,7 +263,6 @@ public class MessageService {
             return;
         }
         final JsonObject frontMsg = new JsonObject();
-
 
         transformMessageZimbraToFront(zimbraMsg, frontMsg, addressMap, response -> {
             zimbraMessages.remove(0);
@@ -212,14 +291,14 @@ public class MessageService {
         }
 
         String flags = msgZimbra.getString(MSG_FLAGS, "");
-        String state = flags.contains(MSG_FLAG_DRAFT) ? "DRAFT" : "SENT";
+        String state = flags.contains(MSG_FLAG_DRAFT) ? STATE_DRAFT : STATE_SENT;
         String folder;
         if (flags.contains(MSG_FLAG_DRAFT)) {
-            folder = "DRAFT";
+            folder = FrontConstants.FOLDER_DRAFT;
         } else if (flags.contains(MSG_FLAG_SENTBYME)) {
-            folder = "OUTBOX";
+            folder = FrontConstants.FOLDER_OUTBOX;
         } else {
-            folder = "INBOX";
+            folder = FrontConstants.FOLDER_INBOX;
         }
 
         msgFront.put("state", state);
@@ -259,6 +338,15 @@ public class MessageService {
         msgFront.put(MESSAGE_ATTACHMENTS, mparts.getAttachmentsJson());
     }
 
+    private boolean displayNamesContainsUserId(JsonArray jsonArray, String userId) {
+        for (Object object : jsonArray) {
+            JsonArray array = (JsonArray) object;
+            if (array.size() > 0 && array.getString(0).equals(userId)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * Process list of mail address in a mail and transform it in Front data
@@ -314,10 +402,17 @@ public class MessageService {
                             frontMsg.put(FrontConstants.IS_REPORT_REQUIRED, true);
                         break;
                 }
-                frontMsg.put(MAIL_DISPLAYNAMES, frontMsg.getJsonArray(MAIL_DISPLAYNAMES, new JsonArray())
-                        .add(new JsonArray()
-                                .add(userUuid)
-                                .add(zimbraUser.getString(MSG_EMAIL_COMMENT, zimbraMail))));
+
+                // Get current displayNames
+                JsonArray displayNames = frontMsg.getJsonArray(MAIL_DISPLAYNAMES, new JsonArray());
+
+                // Check if user is already in displayNames
+                if (!displayNamesContainsUserId(displayNames, userUuid)) {
+                    displayNames.add(new JsonArray()
+                            .add(userUuid)
+                            .add(zimbraUser.getString(MSG_EMAIL_COMMENT, zimbraMail)));
+                }
+
                 zimbraMails.remove(0);
                 translateMaillistToUidlist(frontMsg, zimbraMails, addressMap, isReported, handler);
             };

--- a/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/MessageServiceTest.java
+++ b/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/MessageServiceTest.java
@@ -1,30 +1,45 @@
 package fr.openent.zimbra.service.test.impl;
 
+import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.helper.ServiceManager;
 import fr.openent.zimbra.model.constant.FrontConstants;
 import fr.openent.zimbra.model.constant.ZimbraConstants;
 import fr.openent.zimbra.service.impl.MessageService;
+import fr.openent.zimbra.service.impl.UserService;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import org.powermock.reflect.Whitebox;
 import java.util.HashMap;
+import java.util.List;
 
-@RunWith(VertxUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(VertxUnitRunner.class)
+@PrepareForTest({MessageService.class, UserService.class})
 public class MessageServiceTest {
 
     private MessageService messageService;
+    private UserService userService;
 
     @Before
     public void setUp() {
-        ServiceManager serviceManager = ServiceManager.init(Vertx.vertx(), Vertx.vertx().eventBus(), "", null);
-        this.messageService = serviceManager.getMessageService();
+        this.userService = Mockito.mock(UserService.class);
+        PowerMockito.spy(MessageService.class);
+        this.messageService = PowerMockito.spy(new MessageService(null, null, null, userService, null));
     }
 
     @Test
@@ -55,4 +70,45 @@ public class MessageServiceTest {
                         ctx.assertNull(result.getBoolean(FrontConstants.IS_REPORT_REQUIRED)));
     }
 
+    @Test
+    public void testGetDisplayNames(TestContext ctx) throws Exception {
+        JsonArray frontMessages = new JsonArray();
+        JsonObject frontMessage = new JsonObject();
+        frontMessages.add(frontMessage);
+        JsonArray displayNames = new JsonArray();
+        displayNames.add(new JsonArray().add("a6fc1dbf-5df5-4fd1-a64a-d65d53179f05").add(""));
+        displayNames.add(new JsonArray().add("email@email.com").add(""));
+        displayNames.add(new JsonArray().add("90391c10-996e-444e-8308-9deb921ce51d").add(""));
+        displayNames.add(new JsonArray().add("email@email.com"));
+        frontMessage.put(FrontConstants.MAIL_DISPLAYNAMES, displayNames);
+
+        List<JsonArray> getDisplayNames = Whitebox.invokeMethod(messageService, "getDisplayNames", frontMessages);
+        ctx.assertEquals(2, getDisplayNames.size());
+    }
+
+    @Test
+    public void testRetrieveUsername(TestContext ctx) throws Exception {
+        Async async = ctx.async();
+
+        PowerMockito.doAnswer((Answer<HashMap<String, String>>) invocation -> {
+            Handler<Either<String, JsonArray>> handler = invocation.getArgument(2);
+            JsonArray userIds = new JsonArray();
+            userIds.add(new JsonObject().put(Field.ID, "5eba594c-0d88-4287-af0e-b57e4d981aec").put(Field.USERNAME, "user1"));
+            userIds.add(new JsonObject().put(Field.ID, "2aaad182-659b-4f4f-bb1c-001daf954cd6").put(Field.USERNAME, "user2"));
+            handler.handle(new Either.Right<>(userIds));
+            return null;
+        }).when(userService).getUsers(Mockito.any(), Mockito.any(), Mockito.any());
+
+        Future<HashMap<String, String>> future = Whitebox.invokeMethod(messageService, "retrieveUsernames", Mockito.any());
+        future.onSuccess(res -> {
+            ctx.assertEquals(2, res.size());
+            ctx.assertEquals("user1", res.get("5eba594c-0d88-4287-af0e-b57e4d981aec"));
+            ctx.assertEquals("user2", res.get("2aaad182-659b-4f4f-bb1c-001daf954cd6"));
+            async.complete();
+        }).onFailure(e -> {
+            ctx.fail();
+        });
+
+        async.awaitSuccess(10000);
+    }
 }


### PR DESCRIPTION
## Describe your changes

Displaying usernames correctly when sending mail from Zimbra expert.
Remove duplicates of the same user.

## Checklist tests

- [x] List inbox/outbox with external and internal sender/receiver

## Issue ticket number and link

[JIRA#MZI-136](https://jira.support-ent.fr/browse/MZI-136)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)