### PR TITLE
fix: #MZI-147 fetch emails to be recalled by mid instead of subject and date

### DIFF
--- a/zimbra/src/main/java/fr/openent/zimbra/service/data/SqlDbMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/data/SqlDbMailService.java
@@ -263,8 +263,8 @@ public class SqlDbMailService extends DbMailService {
      */
     public void insertReturnedMail(JsonObject returnedMail, Handler<Either<String, JsonObject>> handler) {
         String query = "INSERT INTO " + this.returnedMailTable +
-                "(user_id, user_name, user_mail, mail_id, structures, object, number_message, recipient, statut, comment, mail_date)" +
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) returning id;";
+                "(user_id, user_name, user_mail, mail_id, structures, object, number_message, recipient, statut, comment, mail_date, mid)" +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) returning id;";
         JsonArray params = new fr.wseduc.webutils.collections.JsonArray()
                 .add(returnedMail.getString("userId"))
                 .add(returnedMail.getString("userName"))
@@ -276,7 +276,8 @@ public class SqlDbMailService extends DbMailService {
                 .add(returnedMail.getJsonArray("to"))
                 .add("WAITING")
                 .add(returnedMail.getString("comment"))
-                .add(returnedMail.getString("mail_date"));
+                .add(returnedMail.getString("mail_date"))
+                .add(returnedMail.getString("mid"));
         sql.prepared(query, params, SqlResult.validUniqueResultHandler(handler));
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -301,6 +301,11 @@ public class MessageService {
             folder = FrontConstants.FOLDER_INBOX;
         }
 
+        if (msgZimbra.containsKey(MSG_EMAILID) && msgZimbra.getString(MSG_EMAILID) != null && msgZimbra.getString(MSG_EMAILID).length() > 1) {
+            String mid = msgZimbra.getString(MSG_EMAILID).substring(1, msgZimbra.getString(MSG_EMAILID).length() - 1);
+            msgFront.put("mid", mid);
+        }
+
         msgFront.put("state", state);
         msgFront.put("unread", flags.contains(MSG_FLAG_UNREAD));
         msgFront.put("response", flags.contains(MSG_FLAG_REPLIED));
@@ -1048,9 +1053,9 @@ public class MessageService {
      * @param result        result handler
      */
     public void retrieveMailFromZimbra(JsonObject returnedMail, JsonObject to_user_infos, Handler<Either<String, List<String>>> result) {
-        String subject = returnedMail.getString("object");
         String from_mail = returnedMail.getString("user_mail");
-        String date = returnedMail.getString("mail_date");
+        String msgid = returnedMail.getString("mid");
+
         String to_user_id = to_user_infos.getString(Field.ID);
         ZimbraUser user = new ZimbraUser(new MailAddress(to_user_infos.getString("mail")));
         user.checkIfExists(userResponse -> {
@@ -1060,7 +1065,7 @@ public class MessageService {
             } else {
                 if (user.existsInZimbra()) {
                     // Etape 3 : On recherche en fonction de l'objet, de l'expéditeur, de la date et de la boite de réception le mail à supprimer
-                    String query = "* NOT in:\"" + "Sent" + "\"" + " AND subject:\"" + subject + "\"" + " AND from:\"" + from_mail + "\"" + " AND date:\"" + date + "\"";
+                    String query = "* NOT in:\"" + "Sent" + "\"" + " AND from:\"" + from_mail + "\"" + " AND msgid:\"" + msgid + "\"";
                     log.info(query);
                     SoapSearchHelper.searchAllMailedConv(to_user_id, 0, query, event -> {
                         if (event.succeeded()) {

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
@@ -370,6 +370,7 @@ public class ReturnedMailService {
                         .put(ZIMBRA_NB_MESSAGES, to.size())
                         .put(MAIL_TO, to)
                         .put(ZIMBRA_MAIL_DATE, mail_date)
+                        .put(MSG_EMAILID, mail.getString(MSG_EMAILID))
                         .put(ZIMBRA_COMMENT, comment);
                 result.handle(new Either.Right<>(returnedMail));
             } else {

--- a/zimbra/src/main/resources/sql/009-zimbra-add-mid-to-mail-returned.sql
+++ b/zimbra/src/main/resources/sql/009-zimbra-add-mid-to-mail-returned.sql
@@ -1,0 +1,2 @@
+ALTER TABLE zimbra.mail_returned
+ADD COLUMN mid character varying;


### PR DESCRIPTION
## Describe your changes

Recovering emails to be recalled with the mail header **Messsage-ID** instead of the subject and the date of the email.
-> More accurate
-> Avoid conflict with a mail that could have the same subject

## Checklist tests

- [x] Tried to recall an email sent to a group
- [x] Tried to recall an email sent to a zimbra account
- [x] Tried to recall an email sent to an external email
- [x] Tried to recall an email sent to a group, a zimbra account and an external email
- [x] Tried ti recall an email sent with copy and carbon copy

## Issue ticket number and link

[JIRA#MZI-147](https://jira.support-ent.fr/browse/MZI-147)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)