### PR TITLE
fix: #MZI-177 improve zimbra request when moving and deleting mails

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,7 @@ zimbraLang = ${String}
     "address-book-account" : "$zimbraAddressBookAccount",
     "admin-password" : "$zimbraAdminPassword",
     "zimbra-synchro-cron" : "$zimbraSynchroCron",
+    "zimbra-file-upload-max-size": $zimbraFileUploadMaxSize,
     "mail-config" : {
       "imaps":{
         ...
@@ -98,6 +99,7 @@ zimbraAdminAccount = ${String}
 zimbraAddressBookAccount = ${String}
 zimbraAdminPassword = ${String}
 zimbraSynchroCron = ${String}
+zimbraFileUploadMaxSize= ${Integer}
 zimbraPurgeEmailedContacts = boolean
 zimbraForceSyncAdressBook = boolean
 saveDraftAutoTime = ${String}

--- a/apizimbra/deployment/apizimbra/conf.json.template
+++ b/apizimbra/deployment/apizimbra/conf.json.template
@@ -1,5 +1,5 @@
     {
-      "name": "fr.openent~apizimbra~2.9.3",
+      "name": "fr.openent~apizimbra~2.9-SNAPSHOT",
       "config": {
         "main" : "fr.openent.apizimbra.ApiZimbra",
         "port" : 8201,

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ subprojects {
     compile "io.vertx:vertx-web-client:$vertxVersion"
     compile "org.entcore:common:$entCoreVersion"
     testCompile "io.vertx:vertx-unit:$vertxVersion"
+    testCompile "io.vertx:vertx-codegen:$vertxVersion"
     testCompile "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     testCompile "org.entcore:tests:$entCoreVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 modowner=fr.openent
 
 # Your module version
-version=2.9.3
+version=2.9-SNAPSHOT
 
 # The test timeout in seconds
 testtimeout=300
@@ -33,4 +33,4 @@ mockitoVersion=2.+
 vertxCronTimer=2.0.0
 webUtilsVersion=2.9.9
 
-entCoreVersion=4.7.1
+entCoreVersion=4.6-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,4 +33,4 @@ mockitoVersion=2.+
 vertxCronTimer=2.0.0
 webUtilsVersion=2.9.9
 
-entCoreVersion=4.6-SNAPSHOT
+entCoreVersion=4.8-SNAPSHOT

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,8 @@ module.exports = {
     "moduleFileExtensions": [
         "ts",
         "tsx",
-        "js"
+        "js",
+        "json"
     ],
     "testPathIgnorePatterns": [
         "/node_modules/",

--- a/zimbra/deployment/zimbra/conf.j2
+++ b/zimbra/deployment/zimbra/conf.j2
@@ -24,6 +24,7 @@
         "admin-account" : "{{ zimbraAdminAccount }}",
         "admin-password" : "{{ zimbraAdminPassword }}",
         "max-recipients" : {{ zimbraMaxRecipients }},
+        "zimbra-file-upload-max-size": {{ zimbraFileUploadMaxSize | default('20') }},
         {% if zimbraCron is defined and zimbraCron %}
         "zimbra-synchro-cron" : "0 5/10 * * * ? *",
         "zimbra-mailer-cron" : "0 0/10 * * * ? *",

--- a/zimbra/deployment/zimbra/conf.json.template
+++ b/zimbra/deployment/zimbra/conf.json.template
@@ -26,6 +26,7 @@
     "address-book-account" : "$zimbraAddressBookAccount",
     "admin-password" : "$zimbraAdminPassword",
     "zimbra-synchro-cron" : "$zimbraSynchroCron",
+    "zimbra-file-upload-max-size": $zimbraFileUploadMaxSize,
     "mail-config" : {
       "imaps":{
         "server":"mx.monlycee.net",

--- a/zimbra/deployment/zimbra/conf.json.template
+++ b/zimbra/deployment/zimbra/conf.json.template
@@ -1,5 +1,5 @@
 {
-  "name": "fr.openent~zimbra~2.9.3",
+  "name": "fr.openent~zimbra~2.9-SNAPSHOT",
   "config": {
     "main" : "fr.openent.zimbra.Zimbra",
     "port" : 8104,
@@ -44,7 +44,6 @@
     "purge-emailed-contacts" : $zimbraPurgeEmailedContacts,
     "force-synchro-adressbook" : $zimbraForceSyncAdressBook,
     "save-draft-auto-time" : $saveDraftAutoTime,
-    "send-timeout" : $sendTimeout,
     "filter-profile-sync-ab" : $filterProfileSyncAB,
     "entcore.port" : 8009,
     "slack": {

--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -506,10 +506,16 @@ public class ZimbraController extends BaseController {
                     b = Boolean.parseBoolean(unread);
                 }
                 messageService.listMessages(folder, b, user, page, search, event -> {
-                    if (!folder.equals("/Sent")) {
+                    if (folder.equals("/Sent")) {
+                        returnedMailService.renderReturnedMail(request, user, event);
+                        return;
+                    }
+
+                    if (event.isRight()) {
                         renderJson(request, event.right().getValue());
                     } else {
-                        returnedMailService.renderReturnedMail(request, user, event);
+                        log.error(String.format("[Zimbra@ZimbraController::listMessages] failed to listMessages: %s", event.left().getValue()));
+                        badRequest(request);
                     }
                 });
             } else {

--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -62,6 +62,7 @@ import org.vertx.java.core.http.RouteMatcher;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static fr.openent.zimbra.model.constant.FrontConstants.MESSAGE_ID;
 import static fr.openent.zimbra.model.constant.ZimbraConstants.ZIMBRA_ID_STRUCTURE;
@@ -387,10 +388,16 @@ public class ZimbraController extends BaseController {
                     returnedMailService.returnMails(user, body, request, returnMailEvent -> {
                         if (returnMailEvent.isRight()) {
                             renderJson(request, returnMailEvent.right().getValue());
-                        } else {
-                            badRequest(request);
-                            log.error("[Zimbra] returnMails : Failed returning mails");
+                            return;
                         }
+
+                        if (Objects.equals(returnMailEvent.left().getValue(), Field.UNAUTHORIZED)) {
+                            unauthorized(request);
+                            return;
+                        }
+
+                        badRequest(request);
+                        log.error("[Zimbra] returnMails : Failed returning mails");
                     });
                 } else {
                     unauthorized(request);

--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -685,18 +685,29 @@ public class ZimbraController extends BaseController {
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     @ResourceFilter(DevLevelFilter.class)
     public void trash(final HttpServerRequest request) {
-        final List<String> messageIds = request.params().getAll(MESSAGE_ID);
-        if (messageIds == null || messageIds.size() == 0) {
-            badRequest(request);
-            return;
-        }
         UserUtils.getUserInfos(eb, request, user -> {
             if (user == null) {
                 unauthorized(request);
                 return;
             }
-            messageService.moveMessagesToFolder(messageIds, FrontConstants.FOLDER_TRASH, user,
-                    defaultResponseHandler(request));
+
+            RequestUtils.bodyToJson(request, body -> {
+                final List<String> messageIds = body.getJsonArray(Field.ID, new JsonArray()).getList().isEmpty() ?
+                        request.params().getAll(MESSAGE_ID) :
+                        body.getJsonArray(Field.ID, new JsonArray()).getList();
+
+                if (messageIds == null || messageIds.isEmpty()) {
+                    badRequest(request);
+                    return;
+                }
+
+                messageService.moveMessagesToFolder(messageIds, FrontConstants.FOLDER_TRASH, user)
+                        .onSuccess(res -> Renders.renderJson(request, new JsonObject(), 200))
+                        .onFailure(err -> {
+                            JsonObject error = (new JsonObject()).put(Field.ERROR, err.getMessage());
+                            Renders.renderJson(request, error, 400);
+                        });
+            });
         });
     }
 
@@ -717,18 +728,29 @@ public class ZimbraController extends BaseController {
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     @ResourceFilter(DevLevelFilter.class)
     public void restore(final HttpServerRequest request) {
-        final List<String> messageIds = request.params().getAll(MESSAGE_ID);
-        if (messageIds == null || messageIds.size() == 0) {
-            badRequest(request);
-            return;
-        }
         UserUtils.getUserInfos(eb, request, user -> {
             if (user == null) {
                 unauthorized(request);
                 return;
             }
-            messageService.moveMessagesToFolder(messageIds, FrontConstants.FOLDER_INBOX, user,
-                    defaultResponseHandler(request));
+
+            RequestUtils.bodyToJson(request, body -> {
+                final List<String> messageIds = body.getJsonArray(Field.ID, new JsonArray()).getList().isEmpty() ?
+                        request.params().getAll(MESSAGE_ID) :
+                        body.getJsonArray(Field.ID, new JsonArray()).getList();
+
+                if (messageIds == null || messageIds.isEmpty()) {
+                    badRequest(request);
+                    return;
+                }
+
+                messageService.moveMessagesToFolder(messageIds, FrontConstants.FOLDER_INBOX, user)
+                        .onSuccess(res -> Renders.renderJson(request, new JsonObject(), 200))
+                        .onFailure(err -> {
+                            JsonObject error = (new JsonObject()).put(Field.ERROR, err.getMessage());
+                            Renders.renderJson(request, error, 400);
+                        });
+            });
         });
     }
 
@@ -749,17 +771,29 @@ public class ZimbraController extends BaseController {
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     @ResourceFilter(DevLevelFilter.class)
     public void delete(final HttpServerRequest request) {
-        final List<String> messageIds = request.params().getAll(MESSAGE_ID);
-        if (messageIds == null || messageIds.isEmpty()) {
-            badRequest(request);
-            return;
-        }
         UserUtils.getUserInfos(eb, request, user -> {
             if (user == null) {
                 unauthorized(request);
                 return;
             }
-            messageService.deleteMessages(messageIds, user, true, defaultResponseHandler(request));
+
+            RequestUtils.bodyToJson(request, body -> {
+                final List<String> messageIds = body.getJsonArray(Field.ID, new JsonArray()).getList().isEmpty() ?
+                        request.params().getAll(MESSAGE_ID) :
+                        body.getJsonArray(Field.ID, new JsonArray()).getList();
+
+                if (messageIds == null || messageIds.isEmpty()) {
+                    badRequest(request);
+                    return;
+                }
+
+                messageService.deleteMessages(messageIds, user, true)
+                        .onSuccess(res -> Renders.renderJson(request, new JsonObject(),200))
+                        .onFailure(err -> {
+                            JsonObject error = (new JsonObject()).put(Field.ERROR, err.getMessage());
+                            Renders.renderJson(request, error, 400);
+                        });
+            });
         });
     }
 
@@ -946,18 +980,30 @@ public class ZimbraController extends BaseController {
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     @ResourceFilter(DevLevelFilter.class)
     public void move(final HttpServerRequest request) {
-        final String folderId = request.params().get("folderId");
-        final List<String> messageIds = request.params().getAll(MESSAGE_ID);
-        if (messageIds == null || messageIds.size() == 0) {
-            badRequest(request);
-            return;
-        }
         UserUtils.getUserInfos(eb, request, user -> {
             if (user == null) {
                 unauthorized(request);
                 return;
             }
-            messageService.moveMessagesToFolder(messageIds, folderId, user, defaultResponseHandler(request));
+
+            RequestUtils.bodyToJson(request, body -> {
+                final String folderId = request.params().get("folderId");
+                final List<String> messageIds = body.getJsonArray(Field.ID, new JsonArray()).getList().isEmpty() ?
+                        request.params().getAll(MESSAGE_ID) :
+                        body.getJsonArray(Field.ID, new JsonArray()).getList();
+
+                if (messageIds == null || messageIds.isEmpty()) {
+                    badRequest(request);
+                    return;
+                }
+
+                messageService.moveMessagesToFolder(messageIds, folderId, user)
+                        .onSuccess(res -> Renders.renderJson(request, new JsonObject(), 200))
+                        .onFailure(err -> {
+                            JsonObject error = (new JsonObject()).put(Field.ERROR, err.getMessage());
+                            Renders.renderJson(request, error, 400);
+                        });
+            });
         });
     }
 
@@ -979,18 +1025,29 @@ public class ZimbraController extends BaseController {
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     @ResourceFilter(DevLevelFilter.class)
     public void rootMove(final HttpServerRequest request) {
-        final List<String> messageIds = request.params().getAll(MESSAGE_ID);
-        if (messageIds == null || messageIds.size() == 0) {
-            badRequest(request);
-            return;
-        }
         UserUtils.getUserInfos(eb, request, user -> {
             if (user == null) {
                 unauthorized(request);
                 return;
             }
-            messageService.moveMessagesToFolder(messageIds, FrontConstants.FOLDER_INBOX, user,
-                    defaultResponseHandler(request));
+
+            RequestUtils.bodyToJson(request, body -> {
+                final List<String> messageIds = body.getJsonArray(Field.ID, new JsonArray()).getList().isEmpty() ?
+                        request.params().getAll(MESSAGE_ID) :
+                        body.getJsonArray(Field.ID, new JsonArray()).getList();
+
+                if (messageIds == null || messageIds.isEmpty()) {
+                    badRequest(request);
+                    return;
+                }
+
+                messageService.moveMessagesToFolder(messageIds, FrontConstants.FOLDER_INBOX, user)
+                        .onSuccess(res -> Renders.renderJson(request, new JsonObject(), 200))
+                        .onFailure(err -> {
+                            JsonObject error = (new JsonObject()).put(Field.ERROR, err.getMessage());
+                            Renders.renderJson(request, error, 400);
+                        });
+            });
         });
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -752,7 +752,7 @@ public class ZimbraController extends BaseController {
                 unauthorized(request);
                 return;
             }
-            messageService.deleteMessages(messageIds, user, defaultResponseHandler(request));
+            messageService.deleteMessages(messageIds, user, true, defaultResponseHandler(request));
         });
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -17,10 +17,11 @@ public class Field {
     public static final String SIZE = "size";
     public static final String APP = "zimbra";
     public static final String FALSE = "false";
-    public static  final String INLINE = "inline";
-    public static  final String HTTPCLIENT = "httpClient";
-    public static  final String ZIMBRARESPONSE = "zimbraResponse";
-    public static  final String UNAUTHORIZED = "unauthorized";
+    public static final String INLINE = "inline";
+    public static final String HTTPCLIENT = "httpClient";
+    public static final String ZIMBRARESPONSE = "zimbraResponse";
+    public static final String USERNAME = "username";
+    public static final String UNAUTHORIZED = "unauthorized";
 
     public static final String MAIL_ATTACHMENT_TOO_BIG = "mail.ATTACHMENT_TOO_BIG";
     public static final String MAIL_INVALID_REQUEST = "mail.INVALID_REQUEST";

--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -21,7 +21,6 @@ public class Field {
     public static  final String HTTPCLIENT = "httpClient";
     public static  final String ZIMBRARESPONSE = "zimbraResponse";
 
-
-
-
+    public static final String MAIL_ATTACHMENT_TOO_BIG = "mail.ATTACHMENT_TOO_BIG";
+    public static final String MAIL_INVALID_REQUEST = "mail.INVALID_REQUEST";
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -20,6 +20,7 @@ public class Field {
     public static  final String INLINE = "inline";
     public static  final String HTTPCLIENT = "httpClient";
     public static  final String ZIMBRARESPONSE = "zimbraResponse";
+    public static  final String UNAUTHORIZED = "unauthorized";
 
     public static final String MAIL_ATTACHMENT_TOO_BIG = "mail.ATTACHMENT_TOO_BIG";
     public static final String MAIL_INVALID_REQUEST = "mail.INVALID_REQUEST";

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/ArrayHelper.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/ArrayHelper.java
@@ -1,0 +1,17 @@
+package fr.openent.zimbra.helper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ArrayHelper {
+    public static <T> List<List<T>> split(List<T> list, int batchSize) {
+        List<List<T>> partitions = new ArrayList<>();
+
+        for (int i = 0; i < list.size(); i += batchSize) {
+            partitions.add(list.subList(i, Math.min(i + batchSize,
+                    list.size())));
+        }
+
+        return partitions;
+    }
+}

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/ConfigManager.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/ConfigManager.java
@@ -51,6 +51,7 @@ public class ConfigManager {
     private final String zimbraAdminPassword;
     private final String preauthKey;
     private final String zimbraDomain;
+    private final Integer zimbraFileUploadMaxSize;
 
     private final String synchroLang;
     private final String synchroCronDate;
@@ -111,6 +112,7 @@ public class ConfigManager {
         this.synchroLang = config.getString("zimbra-synchro-lang", "fr");
         this.synchroCronDate = config.getString("zimbra-synchro-cron", "");
         this.synchroFromMail = config.getString("zimbra-synchro-frommail", "zimbra-sync@cgi.com");
+        this.zimbraFileUploadMaxSize = config.getInteger("zimbra-file-upload-max-size", 20);
         String appSynchroType = config.getString("app-synctype", SYNC_NEO);
         String syncSynchroType = config.getString("sync-synctype", SYNC_NEO);
         this.appSyncTtl = config.getString("app-sync-ttl", "30 minutes");
@@ -183,6 +185,7 @@ public class ConfigManager {
     public String getZimbraAdminPassword() { return zimbraAdminPassword;}
     public String getPreauthKey() { return preauthKey;}
     public String getZimbraDomain() { return zimbraDomain;}
+    public Integer getZimbraFileUploadMaxSize() { return zimbraFileUploadMaxSize;}
     public String getAppSynchroType() { return appSynchroType;}
     public String getSyncSynchroType() { return syncSynchroType;}
     public String getAppSyncTtl() { return appSyncTtl;}

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/StringHelper.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/StringHelper.java
@@ -1,6 +1,7 @@
 package fr.openent.zimbra.helper;
 
 import java.util.List;
+import java.util.UUID;
 
 public class StringHelper {
 
@@ -18,5 +19,14 @@ public class StringHelper {
             sep = separator;
         }
         return sb.toString();
+    }
+
+    public static boolean isUUID(String str) {
+        try {
+            UUID.fromString(str);
+            return true;
+        } catch (IllegalArgumentException exception) {
+            return false;
+        }
     }
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/model/message/Message.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/message/Message.java
@@ -118,12 +118,12 @@ public class Message {
     }
 
     private void setFrontFolder() {
-        if(ZimbraFlags.isDraft(zimbraFlags)){
-            frontFolder = "DRAFT";
-        }else if (ZimbraFlags.isSentByMe(zimbraFlags)) {
-            frontFolder = "OUTBOX";
-        }else {
-            frontFolder = "INBOX";
+        if (ZimbraFlags.isDraft(zimbraFlags)) {
+            frontFolder = FrontConstants.FOLDER_DRAFT;
+        } else if (ZimbraFlags.isSentByMe(zimbraFlags)) {
+            frontFolder = FrontConstants.FOLDER_OUTBOX;
+        } else {
+            frontFolder = FrontConstants.FOLDER_INBOX;
         }
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/service/data/SqlDbMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/data/SqlDbMailService.java
@@ -263,8 +263,8 @@ public class SqlDbMailService extends DbMailService {
      */
     public void insertReturnedMail(JsonObject returnedMail, Handler<Either<String, JsonObject>> handler) {
         String query = "INSERT INTO " + this.returnedMailTable +
-                "(user_id, user_name, user_mail, mail_id, structures, object, number_message, recipient, statut, comment, mail_date)" +
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) returning id;";
+                "(user_id, user_name, user_mail, mail_id, structures, object, number_message, recipient, statut, comment, mail_date, mid)" +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) returning id;";
         JsonArray params = new fr.wseduc.webutils.collections.JsonArray()
                 .add(returnedMail.getString("userId"))
                 .add(returnedMail.getString("userName"))
@@ -276,7 +276,8 @@ public class SqlDbMailService extends DbMailService {
                 .add(returnedMail.getJsonArray("to"))
                 .add("WAITING")
                 .add(returnedMail.getString("comment"))
-                .add(returnedMail.getString("mail_date"));
+                .add(returnedMail.getString("mail_date"))
+                .add(returnedMail.getString("mid"));
         sql.prepared(query, params, SqlResult.validUniqueResultHandler(handler));
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/service/data/SqlDbMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/data/SqlDbMailService.java
@@ -332,12 +332,16 @@ public class SqlDbMailService extends DbMailService {
      * @param ids List of returnedMail ids
      */
     public void getMailReturnedByIds(List<String> ids, Handler<Either<String, JsonArray>> handler) {
+        if (ids.isEmpty()) {
+            handler.handle(new Either.Right<>(new JsonArray()));
+            return;
+        }
         String query = "SELECT *" +
                 " FROM " + this.returnedMailTable +
                 " WHERE id IN " + Sql.listPrepared(ids);
         JsonArray params = new fr.wseduc.webutils.collections.JsonArray();
-        for (int i = 0; i < ids.size(); i++) {
-            params.add(Integer.parseInt(ids.get(i)));
+        for (String id : ids) {
+            params.add(Integer.parseInt(id));
         }
         sql.prepared(query, params, SqlResult.validResultHandler(handler));
     }
@@ -349,13 +353,17 @@ public class SqlDbMailService extends DbMailService {
      * @param user_id Id of the user
      */
     public void getMailReturnedByMailsIdsAndUser(List<String> ids, String user_id, Handler<Either<String, JsonArray>> handler) {
+        if (ids.isEmpty()) {
+            handler.handle(new Either.Right<>(new JsonArray()));
+            return;
+        }
         String query = "SELECT *" +
                 " FROM " + this.returnedMailTable +
                 " WHERE user_id = ? AND mail_id IN " + Sql.listPrepared(ids);
         JsonArray params = new fr.wseduc.webutils.collections.JsonArray();
         params.add(user_id);
-        for (int i = 0; i < ids.size(); i++) {
-            params.add(ids.get(i));
+        for (String id : ids) {
+            params.add(id);
         }
         sql.prepared(query, params, SqlResult.validResultHandler(handler));
     }

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/AttachmentService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/AttachmentService.java
@@ -17,6 +17,7 @@
 
 package fr.openent.zimbra.service.impl;
 
+import fr.openent.zimbra.Zimbra;
 import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.helper.FileHelper;
 import fr.openent.zimbra.helper.HttpClientHelper;
@@ -302,7 +303,7 @@ public class AttachmentService {
                             if (response.statusCode() == 200) {
                                     if (!(Pattern.compile("^.*\"aid\"\\s*:\\s*\"([^\"]*)\".*\n$")).matcher(response.bodyAsString()).find()) {
                                         JsonObject res = new JsonObject()
-                                                .put("code", "mail.INVALID_REQUEST");
+                                                .put("code", Field.MAIL_INVALID_REQUEST);
                                         handler.handle(new Either.Left<>(res.encode()));
                                         return;
                                     }
@@ -344,8 +345,15 @@ public class AttachmentService {
                 if(response.statusCode() == 200) {
                     response.bodyHandler( body -> {
                         if (!(Pattern.compile("^.*\"aid\"\\s*:\\s*\"([^\"]*)\".*\n$")).matcher(body.toString()).find()) {
+                            if (body.toString().matches("^413.*\n$")) {
+                                JsonObject res = new JsonObject()
+                                        .put("code", Field.MAIL_ATTACHMENT_TOO_BIG)
+                                        .put("maxFileSize", Zimbra.appConfig.getZimbraFileUploadMaxSize());
+                                handler.handle(new Either.Left<>(res.encode()));
+                                return;
+                            }
                             JsonObject res = new JsonObject()
-                                    .put("code", "mail.INVALID_REQUEST");
+                                    .put("code", Field.MAIL_INVALID_REQUEST);
                             handler.handle(new Either.Left<>(res.encode()));
                             return;
                         }

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -19,6 +19,7 @@ package fr.openent.zimbra.service.impl;
 
 import fr.openent.zimbra.Zimbra;
 import fr.openent.zimbra.core.constants.Field;
+import fr.openent.zimbra.helper.ArrayHelper;
 import fr.openent.zimbra.helper.ConfigManager;
 import fr.openent.zimbra.helper.FutureHelper;
 import fr.openent.zimbra.helper.StringHelper;
@@ -35,10 +36,7 @@ import fr.openent.zimbra.service.DbMailService;
 import fr.openent.zimbra.service.data.SoapZimbraService;
 import fr.openent.zimbra.service.synchro.SynchroUserService;
 import fr.wseduc.webutils.Either;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
+import io.vertx.core.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
@@ -64,6 +62,8 @@ public class MessageService {
     private final GroupService groupService;
 
     private static final Logger log = LoggerFactory.getLogger(MessageService.class);
+
+    private final int BATCH_SIZE = 100;
 
     public MessageService(SoapZimbraService soapService, FolderService folderService,
                           DbMailService dbMailService, UserService userService, SynchroUserService synchroUserService) {
@@ -927,7 +927,9 @@ public class MessageService {
      * @param folderId       Folder ID destination
      * @param user           User infos
      * @param result         Empty JsonObject returned, no process needed
+     * @deprecated           Use {@link #moveMessagesToFolder(List, String, UserInfos)} instead
      */
+    @Deprecated
     public void moveMessagesToFolder(List<String> listMessageIds, String folderId, UserInfos user,
                                      Handler<Either<String, JsonObject>> result) {
 
@@ -950,6 +952,62 @@ public class MessageService {
         }
     }
 
+    /**
+     * Move emails to Folder
+     *
+     * @param messageIDs     List of Message IDs
+     * @param folderId       Folder ID destination
+     * @param user           User infos
+     */
+    public Future<Void> moveMessagesToFolder(List<String> messageIDs, String folderId, UserInfos user) {
+        Promise<Void> promise = Promise.promise();
+        List<Future<Void>> futures = new ArrayList<>();
+        String zimbraFolderId = folderService.getZimbraFolderId(folderId);
+
+        List<List<String>> batchMessageIds = ArrayHelper.split(messageIDs, BATCH_SIZE);
+        for (List<String> ids : batchMessageIds) {
+            futures.add(this.moveBatchMessageToFolder(ids, zimbraFolderId, user));
+        }
+
+        FutureHelper.all(futures)
+                .onSuccess(res -> promise.complete())
+                .onFailure(err -> promise.fail(err.getMessage()));
+
+        return promise.future();
+    }
+
+    /**
+     * Move a batch of emails to Folder
+     *
+     * @param messageIDs List of Message IDs
+     * @param folderId   Folder ID destination
+     * @param user       User
+     */
+    private Future<Void> moveBatchMessageToFolder(List<String> messageIDs, String folderId, UserInfos user) {
+        Promise<Void> promise = Promise.promise();
+
+        JsonObject actionReq = new JsonObject()
+                .put(MSG_ID, String.join(",", messageIDs))
+                .put(MSG_LOCATION, folderId)
+                .put(OPERATION, OP_MOVE);
+
+        JsonObject convActionRequest = new JsonObject()
+                .put(Field.NAME, "MsgActionRequest")
+                .put(SoapConstants.REQ_CONTENT, new JsonObject()
+                        .put(SoapConstants.ACTION, actionReq)
+                        .put(SoapConstants.REQ_NAMESPACE, SoapConstants.NAMESPACE_MAIL));
+
+        soapService.callUserSoapAPI(convActionRequest, user, response -> {
+            if (response.isLeft()) {
+                promise.fail(response.left().getValue());
+            } else {
+                promise.complete();
+            }
+        });
+
+        return promise.future();
+    }
+
 
     /**
      * Move an email to Folder
@@ -958,7 +1016,9 @@ public class MessageService {
      * @param folderId  Folder ID destination
      * @param user      User
      * @param result    result handler
+     * @deprecated      Use {@link #moveMessagesToFolder(List, String, UserInfos)} instead
      */
+    @Deprecated
     private void moveMessageToFolder(String messageID, String folderId, UserInfos user,
                                      Handler<Either<String, JsonObject>> result) {
         JsonObject actionReq = new JsonObject()
@@ -989,7 +1049,9 @@ public class MessageService {
      * @param user              User infos
      * @param trashConstraint   boolean constraint that messages should be in trash
      * @param result            Empty JsonObject returned, no process needed
+     * @deprecated              Use {@link #deleteMessages(List, UserInfos, boolean)} instead
      */
+    @Deprecated
     public void deleteMessages(List<String> listMessageIds, UserInfos user, boolean trashConstraint,
                                Handler<Either<String, JsonObject>> result) {
 
@@ -1011,6 +1073,64 @@ public class MessageService {
         }
     }
 
+    /**
+     * Delete list of message Ids from trash
+     *
+     * @param messageIDs        List of Message ID
+     * @param user              User infos
+     * @param trashConstraint   boolean constraint that the message should be in trash
+     */
+    public Future<Void> deleteMessages(List<String> messageIDs, UserInfos user, boolean trashConstraint) {
+        Promise<Void> promise = Promise.promise();
+        List<Future<Void>> futures = new ArrayList<>();
+
+        List<List<String>> batchMessageIds = ArrayHelper.split(messageIDs, BATCH_SIZE);
+        for (List<String> ids : batchMessageIds) {
+            futures.add(this.deleteBatchMessages(ids, user, trashConstraint));
+        }
+
+        FutureHelper.all(futures)
+                .onSuccess(res -> promise.complete())
+                .onFailure(err -> promise.fail(err.getMessage()));
+
+        return promise.future();
+    }
+
+    /**
+     * Delete a batch of messages
+     *
+     * @param messageIDs        List of Message ID
+     * @param user              User infos
+     * @param trashConstraint   boolean constraint that the message should be in trash
+     */
+    private Future<Void> deleteBatchMessages(List<String> messageIDs, UserInfos user, boolean trashConstraint) {
+        Promise<Void> promise = Promise.promise();
+
+        JsonObject actionReq = new JsonObject()
+                .put(MSG_ID, String.join(",", messageIDs))
+                .put(OPERATION, OP_DELETE);
+
+        if (trashConstraint) {
+            actionReq.put(MSG_CONSTRAINTS, MSG_CON_TRASH);
+        }
+
+        JsonObject convActionRequest = new JsonObject()
+                .put(Field.NAME, "MsgActionRequest")
+                .put(SoapConstants.REQ_CONTENT, new JsonObject()
+                        .put(SoapConstants.ACTION, actionReq)
+                        .put(SoapConstants.REQ_NAMESPACE, SoapConstants.NAMESPACE_MAIL));
+
+        soapService.callUserSoapAPI(convActionRequest, user, response -> {
+            if (response.isLeft()) {
+                promise.fail(response.left().getValue());
+            } else {
+                promise.complete();
+            }
+        });
+
+        return promise.future();
+    }
+
 
     /**
      * Delete an email from trash
@@ -1019,7 +1139,9 @@ public class MessageService {
      * @param user              User
      * @param trashConstraint   boolean constraint that the message should be in trash
      * @param result            result handler
+     * @deprecated              Use {@link #deleteMessages(List, UserInfos, boolean)} instead
      */
+    @Deprecated
     private void deleteMessage(String messageID, UserInfos user, boolean trashConstraint,
                                Handler<Either<String, JsonObject>> result) {
         JsonObject actionReq = new JsonObject()

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -885,17 +885,18 @@ public class MessageService {
     /**
      * Delete emails from trash
      *
-     * @param listMessageIds Messages ID list selected
-     * @param user           User infos
-     * @param result         Empty JsonObject returned, no process needed
+     * @param listMessageIds    Messages ID list selected
+     * @param user              User infos
+     * @param trashConstraint   boolean constraint that messages should be in trash
+     * @param result            Empty JsonObject returned, no process needed
      */
-    public void deleteMessages(List<String> listMessageIds, UserInfos user,
+    public void deleteMessages(List<String> listMessageIds, UserInfos user, boolean trashConstraint,
                                Handler<Either<String, JsonObject>> result) {
 
         final AtomicInteger processedIds = new AtomicInteger(listMessageIds.size());
         final AtomicInteger successMessages = new AtomicInteger(0);
         for (String messageID : listMessageIds) {
-            deleteMessage(messageID, user, resultHandler -> {
+            deleteMessage(messageID, user, trashConstraint, resultHandler -> {
                 if (resultHandler.isRight()) {
                     successMessages.incrementAndGet();
                 }
@@ -914,16 +915,20 @@ public class MessageService {
     /**
      * Delete an email from trash
      *
-     * @param messageID Message ID
-     * @param user      User
-     * @param result    result handler
+     * @param messageID         Message ID
+     * @param user              User
+     * @param trashConstraint   boolean constraint that the message should be in trash
+     * @param result            result handler
      */
-    private void deleteMessage(String messageID, UserInfos user,
+    private void deleteMessage(String messageID, UserInfos user, boolean trashConstraint,
                                Handler<Either<String, JsonObject>> result) {
         JsonObject actionReq = new JsonObject()
                 .put(MSG_ID, messageID)
-                .put(OPERATION, OP_DELETE)
-                .put(MSG_CONSTRAINTS, MSG_CON_TRASH);
+                .put(OPERATION, OP_DELETE);
+
+        if (trashConstraint) {
+            actionReq.put(MSG_CONSTRAINTS, MSG_CON_TRASH);
+        }
 
         JsonObject convActionRequest = new JsonObject()
                 .put(Field.NAME, "MsgActionRequest")

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -21,6 +21,7 @@ import fr.openent.zimbra.Zimbra;
 import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.helper.ConfigManager;
 import fr.openent.zimbra.helper.FutureHelper;
+import fr.openent.zimbra.helper.StringHelper;
 import fr.openent.zimbra.model.MailAddress;
 import fr.openent.zimbra.model.ZimbraUser;
 import fr.openent.zimbra.model.constant.FrontConstants;
@@ -44,10 +45,7 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.entcore.common.user.UserInfos;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -64,6 +62,7 @@ public class MessageService {
     private final DbMailService dbMailService;
     private final UserService userService;
     private final GroupService groupService;
+
     private static final Logger log = LoggerFactory.getLogger(MessageService.class);
 
     public MessageService(SoapZimbraService soapService, FolderService folderService,
@@ -142,6 +141,85 @@ public class MessageService {
     }
 
     /**
+     * Add displayNames to frontMsg response
+     *
+     * @param frontMessages
+     * @return
+     */
+    private Future<Void> addDisplayNames(JsonArray frontMessages) {
+        Promise<Void> promise = Promise.promise();
+
+        List<JsonArray> displayNames = this.getDisplayNames(frontMessages);
+        JsonArray userIds = new JsonArray();
+        displayNames.forEach(displayName -> userIds.add(displayName.getString(0)));
+
+        this.retrieveUsernames(userIds)
+                .onSuccess(usernames -> {
+                    displayNames.forEach(displayName -> {
+                        String username = usernames.get(displayName.getString(0));
+                        displayName.set(1, username);
+                    });
+                    promise.complete();
+                })
+                .onFailure(e -> promise.fail(e.getMessage()));
+
+        return promise.future();
+    }
+
+    /**
+     * Extract displayNames from frontMsg
+     *
+     * @param frontMessages
+     * @return
+     */
+    private List<JsonArray> getDisplayNames(JsonArray frontMessages) {
+        List<JsonArray> response = new ArrayList<>();
+        for (Object obj : frontMessages) {
+            JsonObject mail = (JsonObject) obj;
+            JsonArray displayNames = mail.getJsonArray(FrontConstants.MAIL_DISPLAYNAMES, new JsonArray());
+            for (Object displayName : displayNames) {
+                if (!(displayName instanceof JsonArray) || ((JsonArray) displayName).size() == 0) continue;
+                String userId = ((JsonArray) displayName).getString(0);
+                if (userId != null && StringHelper.isUUID(userId)) {
+                    response.add((JsonArray) displayName);
+                }
+            }
+        }
+        return response;
+    }
+
+    /**
+     * Retrieve username from entcore with JsonArray of userIds
+     *
+     * @param userIds JsonArray of userIds
+     * @return Future of HashMap<String, String>
+     */
+    private Future<HashMap<String, String>> retrieveUsernames(JsonArray userIds) {
+        Promise<HashMap<String, String>> promise = Promise.promise();
+
+        userService.getUsers(userIds, userIds, (response) -> {
+            if (response.isLeft()) {
+                promise.fail(response.left().getValue());
+            } else {
+                List<JsonObject> users = response.right().getValue().getList();
+
+                HashMap<String, String> usernames = new HashMap<>();
+                for (JsonObject user : users) {
+                    String id = user.getString(Field.ID);
+                    String username = user.getString(Field.USERNAME);
+                    if (id != null && username != null) {
+                        usernames.put(id, username);
+                    }
+                }
+
+                promise.complete(usernames);
+            }
+        });
+
+        return promise.future();
+    }
+
+    /**
      * Process recursively a zimbra searchResult and transform it to Front Message
      * Form of Front message returned :
      * {
@@ -171,7 +249,9 @@ public class MessageService {
     private void processSearchResult(JsonArray zimbraMessages, JsonArray frontMessages, Map<String, String> addressMap,
                                      Handler<Either<String, JsonArray>> result) {
         if (zimbraMessages.isEmpty()) {
-            result.handle(new Either.Right<>(frontMessages));
+            this.addDisplayNames(frontMessages)
+                    .onSuccess(res -> result.handle(new Either.Right<>(frontMessages)))
+                    .onFailure(res -> result.handle(new Either.Left<>(res.getMessage())));
             return;
         }
         JsonObject zimbraMsg;
@@ -183,7 +263,6 @@ public class MessageService {
             return;
         }
         final JsonObject frontMsg = new JsonObject();
-
 
         transformMessageZimbraToFront(zimbraMsg, frontMsg, addressMap, response -> {
             zimbraMessages.remove(0);
@@ -212,14 +291,14 @@ public class MessageService {
         }
 
         String flags = msgZimbra.getString(MSG_FLAGS, "");
-        String state = flags.contains(MSG_FLAG_DRAFT) ? "DRAFT" : "SENT";
+        String state = flags.contains(MSG_FLAG_DRAFT) ? STATE_DRAFT : STATE_SENT;
         String folder;
         if (flags.contains(MSG_FLAG_DRAFT)) {
-            folder = "DRAFT";
+            folder = FrontConstants.FOLDER_DRAFT;
         } else if (flags.contains(MSG_FLAG_SENTBYME)) {
-            folder = "OUTBOX";
+            folder = FrontConstants.FOLDER_OUTBOX;
         } else {
-            folder = "INBOX";
+            folder = FrontConstants.FOLDER_INBOX;
         }
 
         msgFront.put("state", state);
@@ -259,6 +338,15 @@ public class MessageService {
         msgFront.put(MESSAGE_ATTACHMENTS, mparts.getAttachmentsJson());
     }
 
+    private boolean displayNamesContainsUserId(JsonArray jsonArray, String userId) {
+        for (Object object : jsonArray) {
+            JsonArray array = (JsonArray) object;
+            if (array.size() > 0 && array.getString(0).equals(userId)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * Process list of mail address in a mail and transform it in Front data
@@ -314,10 +402,17 @@ public class MessageService {
                             frontMsg.put(FrontConstants.IS_REPORT_REQUIRED, true);
                         break;
                 }
-                frontMsg.put(MAIL_DISPLAYNAMES, frontMsg.getJsonArray(MAIL_DISPLAYNAMES, new JsonArray())
-                        .add(new JsonArray()
-                                .add(userUuid)
-                                .add(zimbraUser.getString(MSG_EMAIL_COMMENT, zimbraMail))));
+
+                // Get current displayNames
+                JsonArray displayNames = frontMsg.getJsonArray(MAIL_DISPLAYNAMES, new JsonArray());
+
+                // Check if user is already in displayNames
+                if (!displayNamesContainsUserId(displayNames, userUuid)) {
+                    displayNames.add(new JsonArray()
+                            .add(userUuid)
+                            .add(zimbraUser.getString(MSG_EMAIL_COMMENT, zimbraMail)));
+                }
+
                 zimbraMails.remove(0);
                 translateMaillistToUidlist(frontMsg, zimbraMails, addressMap, isReported, handler);
             };

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -301,6 +301,11 @@ public class MessageService {
             folder = FrontConstants.FOLDER_INBOX;
         }
 
+        if (msgZimbra.containsKey(MSG_EMAILID) && msgZimbra.getString(MSG_EMAILID) != null && msgZimbra.getString(MSG_EMAILID).length() > 1) {
+            String mid = msgZimbra.getString(MSG_EMAILID).substring(1, msgZimbra.getString(MSG_EMAILID).length() - 1);
+            msgFront.put("mid", mid);
+        }
+
         msgFront.put("state", state);
         msgFront.put("unread", flags.contains(MSG_FLAG_UNREAD));
         msgFront.put("response", flags.contains(MSG_FLAG_REPLIED));
@@ -1048,9 +1053,9 @@ public class MessageService {
      * @param result        result handler
      */
     public void retrieveMailFromZimbra(JsonObject returnedMail, JsonObject to_user_infos, Handler<Either<String, List<String>>> result) {
-        String subject = returnedMail.getString("object");
         String from_mail = returnedMail.getString("user_mail");
-        String date = returnedMail.getString("mail_date");
+        String msgid = returnedMail.getString("mid");
+
         String to_user_id = to_user_infos.getString(Field.ID);
         ZimbraUser user = new ZimbraUser(new MailAddress(to_user_infos.getString("mail")));
         user.checkIfExists(userResponse -> {
@@ -1060,7 +1065,7 @@ public class MessageService {
             } else {
                 if (user.existsInZimbra()) {
                     // Etape 3 : On recherche en fonction de l'objet, de l'expéditeur, de la date et de la boite de réception le mail à supprimer
-                    String query = "* NOT in:\"" + "Sent" + "\"" + " AND subject:\"" + subject + "\"" + " AND from:\"" + from_mail + "\"" + " AND date:\"" + date + "\"";
+                    String query = "* NOT in:\"" + "Sent" + "\"" + " AND from:\"" + from_mail + "\"" + " AND msgid:\"" + msgid + "\"";
                     log.info(query);
                     SoapSearchHelper.searchAllMailedConv(to_user_id, 0, query, event -> {
                         if (event.succeeded()) {

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
@@ -252,6 +252,10 @@ public class ReturnedMailService {
     private void addDeleteFutures(JsonObject returnedMail, Handler<Either<String, JsonObject>> result) {
         JsonArray userIds = new JsonArray(returnedMail.getString(NOTIF_RECIPIENT));
         int j = 0;
+        if (userIds.isEmpty()) {
+            result.handle(new Either.Right<>(new JsonObject()));
+            return;
+        }
         this.recursiveDeleteMail(userIds, j, returnedMail, deleteEvent -> {
             if (deleteEvent.isRight()) {
                 result.handle(new Either.Right<>(deleteEvent.right().getValue()));
@@ -326,11 +330,13 @@ public class ReturnedMailService {
                             if (event.isRight()) {
                                 handler.handle(new Either.Right<>(event.right().getValue()));
                             } else {
-                                handler.handle(new Either.Left<>("[Zimbra] getReturnedMailsInfos : Error while deleting mails : " + event.left().getValue()));
+                                log.error(String.format("[Zimbra@%s::deleteMailFromZimbra] Error when deleting mails: %s", this.getClass().getSimpleName(), event.left().getValue()));
+                                handler.handle(new Either.Left<>(event.left().getValue()));
                             }
                         });
                     } else {
-                        log.error("Erreur lors du déplacement vers la corbeille du mail " + ids.get(0));
+                        log.error(String.format("[Zimbra@%s::deleteMailFromZimbra] Error when moving to trash: %s, %s", this.getClass().getSimpleName(), ids.get(0), moveToTrash.left().getValue()));
+                        handler.handle(new Either.Left<>(moveToTrash.left().getValue()));
                     }
                 });
     }

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
@@ -321,24 +321,16 @@ public class ReturnedMailService {
     }
 
     private void deleteMailFromZimbra(List<String> ids, UserInfos user, Handler<Either<String, JsonObject>> handler) {
-        // Etape 4 : On déplace le mail à supprimer vers la corbeille
-        messageService.moveMessagesToFolder(ids, FrontConstants.FOLDER_TRASH, user,
-                moveToTrash -> {
-                    if (moveToTrash.isRight()) {
-                        // Etape 5 : On supprime définitivement le message de la boite de réception
-                        messageService.deleteMessages(ids, user, event -> {
-                            if (event.isRight()) {
-                                handler.handle(new Either.Right<>(event.right().getValue()));
-                            } else {
-                                log.error(String.format("[Zimbra@%s::deleteMailFromZimbra] Error when deleting mails: %s", this.getClass().getSimpleName(), event.left().getValue()));
-                                handler.handle(new Either.Left<>(event.left().getValue()));
-                            }
-                        });
-                    } else {
-                        log.error(String.format("[Zimbra@%s::deleteMailFromZimbra] Error when moving to trash: %s, %s", this.getClass().getSimpleName(), ids.get(0), moveToTrash.left().getValue()));
-                        handler.handle(new Either.Left<>(moveToTrash.left().getValue()));
-                    }
-                });
+        // Etape 4 : On supprime définitivement le message de la boite de réception
+        messageService.deleteMessages(ids, user, false, event -> {
+            if (event.isRight()) {
+                handler.handle(new Either.Right<>(event.right().getValue()));
+            } else {
+                log.error(String.format("[Zimbra@%s::deleteMailFromZimbra] Error when deleting mails: %s",
+                        this.getClass().getSimpleName(), event.left().getValue()));
+                handler.handle(new Either.Left<>(event.left().getValue()));
+            }
+        });
     }
 
     private void getReturnedMailsInfos(JsonObject mail, String comment, UserInfos

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
@@ -1,6 +1,7 @@
 package fr.openent.zimbra.service.impl;
 
 import fr.openent.zimbra.Zimbra;
+import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.helper.JsonHelper;
 import fr.openent.zimbra.model.constant.FrontConstants;
 import fr.openent.zimbra.service.DbMailService;
@@ -54,6 +55,10 @@ public class ReturnedMailService {
         messageService.getMessage(messagesId, user, getMail -> {
             if (getMail.isRight()) {
                 JsonObject mail = getMail.right().getValue();
+                if (!Objects.equals(mail.getString(MAIL_FROM), user.getUserId())) {
+                    result.handle(new Either.Left<>(Field.UNAUTHORIZED));
+                    return;
+                }
                 this.getReturnedMailsInfos(mail, comment, user, returnedMailsEvent -> {
                     if (returnedMailsEvent.isRight()) {
                         JsonObject returnedMail = returnedMailsEvent.right().getValue();

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
@@ -403,15 +403,19 @@ public class ReturnedMailService {
     public void deleteMailsProgress(Handler<Either<String, JsonObject>> handler) {
         this.getMailReturnedByStatut("PROGRESS", returnedMailsIdsEvent -> {
             if (returnedMailsIdsEvent.isRight()) {
-                List<String> returnedMailsIds = JsonHelper.extractValueFromJsonObjects(returnedMailsIdsEvent.right().getValue(), MESSAGE_ID);
-                this.deleteMessages(returnedMailsIds, deleteMailEvent -> {
-                    if (deleteMailEvent.isRight()) {
-                        handler.handle(new Either.Right(deleteMailEvent.right().getValue()));
-                    } else {
-                        handler.handle(new Either.Left("[Zimbra] deleteMailsProgress : Failed deleting mails"));
-                        log.error("[Zimbra] deleteMailsProgress : Failed deleting mails");
-                    }
-                });
+                if (returnedMailsIdsEvent.right().getValue().size() > 0) {
+                    List<String> returnedMailsIds = JsonHelper.extractValueFromJsonObjects(returnedMailsIdsEvent.right().getValue(), MESSAGE_ID);
+                    this.deleteMessages(returnedMailsIds, deleteMailEvent -> {
+                        if (deleteMailEvent.isRight()) {
+                            handler.handle(new Either.Right(deleteMailEvent.right().getValue()));
+                        } else {
+                            handler.handle(new Either.Left("[Zimbra] deleteMailsProgress : Failed deleting mails"));
+                            log.error("[Zimbra] deleteMailsProgress : Failed deleting mails");
+                        }
+                    });
+                } else {
+                    handler.handle(new Either.Right(new JsonObject()));
+                }
             } else {
                 handler.handle(new Either.Left("[Zimbra] deleteMailsProgress : Failed to retrieve mail in progress"));
                 log.error("[Zimbra] deleteMailsProgress : Failed to retrieve mail in progress");

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
@@ -324,6 +324,8 @@ public class ReturnedMailService {
         // Etape 4 : On supprime définitivement le message de la boite de réception
         messageService.deleteMessages(ids, user, false, event -> {
             if (event.isRight()) {
+                log.info(String.format("[Zimbra@%s::deleteMailFromZimbra] Success of deleting mails %s of the user %s",
+                        this.getClass().getSimpleName(), ids, user.getUserId()));
                 handler.handle(new Either.Right<>(event.right().getValue()));
             } else {
                 log.error(String.format("[Zimbra@%s::deleteMailFromZimbra] Error when deleting mails: %s",

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
@@ -370,6 +370,7 @@ public class ReturnedMailService {
                         .put(ZIMBRA_NB_MESSAGES, to.size())
                         .put(MAIL_TO, to)
                         .put(ZIMBRA_MAIL_DATE, mail_date)
+                        .put(MSG_EMAILID, mail.getString(MSG_EMAILID))
                         .put(ZIMBRA_COMMENT, comment);
                 result.handle(new Either.Right<>(returnedMail));
             } else {

--- a/zimbra/src/main/resources/i18n/en.json
+++ b/zimbra/src/main/resources/i18n/en.json
@@ -132,5 +132,6 @@
     "yesterday": "Hier",
     "you.answered": "You answered to this message",
     "zimbra.outside.donotchange": "External Mail [Do Not Change]",
-  "account.myaccount": "My account"
+    "zimbra.external.user": "Only mails sended to internal ENT users will be recalled",
+    "account.myaccount": "My account"
 }

--- a/zimbra/src/main/resources/i18n/en.json
+++ b/zimbra/src/main/resources/i18n/en.json
@@ -71,7 +71,7 @@
     "mail-in": "Message de la boîte de réception",
     "mail-new": "Message brouillon",
     "mail-out": "Message de la boîte d'envoi",
-    "mail.move": "Déplacer le(s) message(s)",
+    "mail.move": "Move mails to",
     "mail.sent": "Mail sent",
     "me": "Me",
     "message": "message",
@@ -79,7 +79,7 @@
     "ml.sent": "Message envoyé",
     "modify": "Modifier",
     "move": "move",
-    "move.first.caps": "Déplacer",
+    "move.first.caps": "Move",
     "move.inside.folder": "Déplacer dans un dossier",
     "name": "Nom",
     "new.message": "New message",
@@ -133,5 +133,7 @@
     "you.answered": "You answered to this message",
     "zimbra.outside.donotchange": "External Mail [Do Not Change]",
     "zimbra.external.user": "Only mails sended to internal ENT users will be recalled",
-    "account.myaccount": "My account"
+    "account.myaccount": "My account",
+    "message.folder": "Messages folders",
+    "personal.folder": "Personal folders"
 }

--- a/zimbra/src/main/resources/i18n/fr.json
+++ b/zimbra/src/main/resources/i18n/fr.json
@@ -87,7 +87,7 @@
     "mail-in": "Message de la boîte de réception",
     "mail-new": "Message brouillon",
     "mail-out": "Message de la boîte d'envoi",
-    "mail.move": "Déplacer le(s) message(s)",
+    "mail.move": "Déplacer le(s) message(s) vers",
     "mail.sent": "Message envoyé",
     "me": "Moi",
     "message": "le message",
@@ -225,5 +225,7 @@
     "zimbra.quota.info.warning": "Votre boîte aux lettres est pleine. Votre boîte aux lettres ne peut plus envoyer de messages. Réduisez sa taille. Supprimez de votre boîte aux lettres les éléments superflus et videz votre dossier Corbeille.",
     "zimbra.default.intern.error": "Erreur interne: ",
     "zimbra.external.user": "Seuls les mails adressés aux destinataires internes á l'ENT seront rappelés",
-    "zimbra.share.search.help": "Ex : Sabine, Dupont, Enseignants..."
+    "zimbra.share.search.help": "Ex : Sabine, Dupont, Enseignants...",
+    "message.folder": "Dossiers de messagerie",
+    "personal.folder": "Dossiers personnels"
 }

--- a/zimbra/src/main/resources/i18n/fr.json
+++ b/zimbra/src/main/resources/i18n/fr.json
@@ -224,5 +224,6 @@
     "zimbra.quota.info.message": "Votre boîte aux lettres est presque pleine. Réduisez la taille de votre boîte aux lettres en supprimant de cette dernière les éléments superflus et en vidant le dossier Corbeille.",
     "zimbra.quota.info.warning": "Votre boîte aux lettres est pleine. Votre boîte aux lettres ne peut plus envoyer de messages. Réduisez sa taille. Supprimez de votre boîte aux lettres les éléments superflus et videz votre dossier Corbeille.",
     "zimbra.default.intern.error": "Erreur interne: ",
+    "zimbra.external.user": "Seuls les mails adressés aux destinataires internes á l'ENT seront rappelés",
     "zimbra.share.search.help": "Ex : Sabine, Dupont, Enseignants..."
 }

--- a/zimbra/src/main/resources/i18n/fr.json
+++ b/zimbra/src/main/resources/i18n/fr.json
@@ -211,6 +211,7 @@
     "Teacher": "Enseignant",
     "zimbra.message.error.attachment": "Une erreur est survenue lors de l'ajout de la pièce jointe, vérifiez la taille de votre mail",
     "zimbra.message.error.attachment.size": "Le fichier sélectionné ne peut être ajouté en pièce jointe car il dépasse la taille maximale autorisée ({{maxFileSize}} Mo)",
+    "zimbra.message.error.attachment.size2": "Le fichier sélectionné ne peut être ajouté en pièce jointe car il dépasse la taille maximale autorisée",
     "zimbra.message.error.attachments": "Une erreur est survenue lors de l'ajout de la pièce jointe",
     "zimbra.message.error.mail.size": "La taille de vos pièces jointes est trop importante, vérifiez la taille de votre mail",
     "zimbra.message.info.iframe": "Le mail contient un code HTML qui n'est pas interprété, vous ne pourrez pas l'envoyer (iframe)",

--- a/zimbra/src/main/resources/i18n/fr.json
+++ b/zimbra/src/main/resources/i18n/fr.json
@@ -210,6 +210,7 @@
     "Relative": "Parent",
     "Teacher": "Enseignant",
     "zimbra.message.error.attachment": "Une erreur est survenue lors de l'ajout de la pièce jointe, vérifiez la taille de votre mail",
+    "zimbra.message.error.attachment.size": "Le fichier sélectionné ne peut être ajouté en pièce jointe car il dépasse la taille maximale autorisée ({{maxFileSize}} Mo)",
     "zimbra.message.error.attachments": "Une erreur est survenue lors de l'ajout de la pièce jointe",
     "zimbra.message.error.mail.size": "La taille de vos pièces jointes est trop importante, vérifiez la taille de votre mail",
     "zimbra.message.info.iframe": "Le mail contient un code HTML qui n'est pas interprété, vous ne pourrez pas l'envoyer (iframe)",

--- a/zimbra/src/main/resources/public/template/folders-templates/toaster.html
+++ b/zimbra/src/main/resources/public/template/folders-templates/toaster.html
@@ -27,10 +27,8 @@
                 <button ng-click="moveSelection()" ng-if="zimbra.currentFolder.mails.selection.length && zimbra.currentFolder.folderName !== 'trash'">
                 <i18n>move.inside.folder</i18n>
             </button>
-            <button ng-click="returnSelection()"
-                    ng-if="zimbra.currentFolder.mails.selection.selectedElements.length < 2 &&
-                    zimbra.currentFolder.mails.selection.selectedElements[0].returned == 'NONE' &&
-                    zimbra.currentFolder.folderName === 'outbox'"
+            <button ng-click="toggleRecallView()"
+                    ng-if="isSelectedRecallable() && zimbra.currentFolder.folderName === 'outbox'"
                     workflow="zimbra.return" >
                 <i18n>return</i18n>
             </button>

--- a/zimbra/src/main/resources/public/template/folders-templates/toaster.html
+++ b/zimbra/src/main/resources/public/template/folders-templates/toaster.html
@@ -29,19 +29,19 @@
             </button>
             <button ng-click="toggleRecallView()"
                     ng-if="isSelectedRecallable() && zimbra.currentFolder.folderName === 'outbox'"
-                    workflow="zimbra.return" >
+                    workflow="zimbra.return">
                 <i18n>return</i18n>
             </button>
             <button ng-click="removeFromUserFolder()" ng-if="zimbra.currentFolder.mails.selection.length && zimbra.currentFolder.id">
                 <i18n>remove.from.folder</i18n>
             </button>
             <button ng-click="toggleUnreadSelection(false, zimbra.currentFolder)" ng-if="
-                    zimbra.currentFolder.mails.selection.length && (zimbra.currentFolder.folderName === 'inbox' || zimbra.currentFolder.id) &&
+                    zimbra.currentFolder.mails.selection.length && (zimbra.currentFolder.folderName === 'inbox' || zimbra.currentFolder.id) &&
                     canMarkRead() ">
                 <i18n>tag.read</i18n>
             </button>
             <button ng-click="toggleUnreadSelection(true, zimbra.currentFolder)" ng-if="
-                    zimbra.currentFolder.mails.selection.length && (zimbra.currentFolder.folderName === 'inbox' || zimbra.currentFolder.id) &&
+                    zimbra.currentFolder.mails.selection.length && (zimbra.currentFolder.folderName === 'inbox' || zimbra.currentFolder.id) &&
                     canMarkUnread()">
                 <i18n>tag.unread</i18n>
             </button>

--- a/zimbra/src/main/resources/public/template/folders-templates/toaster.html
+++ b/zimbra/src/main/resources/public/template/folders-templates/toaster.html
@@ -21,19 +21,16 @@
             <button ng-click="showConfirm()" ng-if="zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length">
                 <i18n>remove</i18n>
             </button>
-            <button ng-click="restore()" ng-if="(zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length) && zimbra.currentFolder.folderName === 'trash'">
-                <i18n>restore</i18n>
+            <button ng-click="moveSelection()" ng-if="(zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length) && (zimbra.currentFolder.folderName === 'trash' || userFolders.all.includes(zimbra.currentFolder))">
+                <i18n>move.first.caps</i18n>
             </button>
-                <button ng-click="moveSelection()" ng-if="zimbra.currentFolder.mails.selection.length && zimbra.currentFolder.folderName !== 'trash'">
+                <button ng-click="moveSelection()" ng-if="zimbra.currentFolder.mails.selection.length && folders.list.includes(zimbra.currentFolder) && zimbra.currentFolder.folderName !== 'trash'">
                 <i18n>move.inside.folder</i18n>
             </button>
             <button ng-click="toggleRecallView()"
                     ng-if="isSelectedRecallable() && zimbra.currentFolder.folderName === 'outbox'"
                     workflow="zimbra.return">
                 <i18n>return</i18n>
-            </button>
-            <button ng-click="removeFromUserFolder()" ng-if="zimbra.currentFolder.mails.selection.length && zimbra.currentFolder.id">
-                <i18n>remove.from.folder</i18n>
             </button>
             <button ng-click="toggleUnreadSelection(false, zimbra.currentFolder)" ng-if="
                     zimbra.currentFolder.mails.selection.length && (zimbra.currentFolder.folderName === 'inbox' || zimbra.currentFolder.id) &&

--- a/zimbra/src/main/resources/public/template/folders-templates/toaster.html
+++ b/zimbra/src/main/resources/public/template/folders-templates/toaster.html
@@ -21,7 +21,7 @@
             <button ng-click="showConfirm()" ng-if="zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length">
                 <i18n>remove</i18n>
             </button>
-            <button ng-click="moveSelection()" ng-if="(zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length) && (zimbra.currentFolder.folderName === 'trash' || userFolders.all.includes(zimbra.currentFolder))">
+            <button ng-click="moveSelection()" ng-if="(zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length) && (zimbra.currentFolder.folderName === 'trash' || !folders.list.includes(zimbra.currentFolder))">
                 <i18n>move.first.caps</i18n>
             </button>
                 <button ng-click="moveSelection()" ng-if="zimbra.currentFolder.mails.selection.length && folders.list.includes(zimbra.currentFolder) && zimbra.currentFolder.folderName !== 'trash'">

--- a/zimbra/src/main/resources/public/template/mail-actions/read-mail.html
+++ b/zimbra/src/main/resources/public/template/mail-actions/read-mail.html
@@ -23,6 +23,12 @@
 			<button ng-click="transfer()"><i18n>transfer</i18n></button>
 			<a class="button"   target="_blank" ng-href="/zimbra/print#/printMail/[[mail.id]]"><i18n>print</i18n></a>
 			<button ng-click="removeMail()"><i18n>remove</i18n></button>
+			<button ng-click="moveSelection()" ng-if="!folders.list.includes(zimbra.currentFolder)">
+				<i18n>move.first.caps</i18n>
+			</button>
+			<button ng-click="moveSelection()" ng-if="folders.list.includes(zimbra.currentFolder) && zimbra.currentFolder.folderName !== 'trash'">
+				<i18n>move.inside.folder</i18n>
+			</button>
 		</plus>
 		<!-- Reply not allowed if deleted user -->
 		<button class="right-magnet" ng-click="reply()" ng-disabled="!mail.allowReply">

--- a/zimbra/src/main/resources/public/template/mail-actions/view-mail.html
+++ b/zimbra/src/main/resources/public/template/mail-actions/view-mail.html
@@ -24,7 +24,7 @@
 				<button ng-click="replyAll()" ng-disabled="!mail.allowReplyAll"><i18n>replyall</i18n></button>
 				<a class="button"   target="_blank" ng-href="/zimbra/print#/printMail/[[mail.id]]"><i18n>print</i18n></a>
 				<button ng-click="mail.remove(); openFolder()"><i18n>remove</i18n></button>
-				<button ng-click="returnSelection()" ng-if="mail.returned == 'NONE'">
+				<button ng-click="toggleRecallView()" ng-if="isRecallable(mail)">
 					<i18n>return</i18n>
 				</button>
 			</plus>

--- a/zimbra/src/main/resources/public/template/mail-actions/view-mail.html
+++ b/zimbra/src/main/resources/public/template/mail-actions/view-mail.html
@@ -24,8 +24,14 @@
 				<button ng-click="replyAll()" ng-disabled="!mail.allowReplyAll"><i18n>replyall</i18n></button>
 				<a class="button"   target="_blank" ng-href="/zimbra/print#/printMail/[[mail.id]]"><i18n>print</i18n></a>
 				<button ng-click="mail.remove(); openFolder()"><i18n>remove</i18n></button>
-				<button ng-click="toggleRecallView()" ng-if="isRecallable(mail)">
+				<button ng-click="toggleRecallView()" ng-if="isRecallable(mail) && zimbra.currentFolder.folderName === 'outbox'">
 					<i18n>return</i18n>
+				</button>
+				<button ng-click="moveSelection()" ng-if="!folders.list.includes(zimbra.currentFolder)">
+					<i18n>move.first.caps</i18n>
+				</button>
+				<button ng-click="moveSelection()" ng-if="folders.list.includes(zimbra.currentFolder) && zimbra.currentFolder.folderName !== 'trash'">
+					<i18n>move.inside.folder</i18n>
 				</button>
 			</plus>
 			<button ng-click="transfer()" class="right-magnet"><i18n>transfer</i18n></button>
@@ -35,12 +41,18 @@
 				<a class="button"   target="_blank" ng-href="/zimbra/print#/printMail/[[mail.id]]"><i18n>print</i18n></a>
 				<button ng-click="mail.remove(); openFolder()"><i18n>remove</i18n></button>
 			</plus>
-			<button ng-click="mail.restore(); openFolder('trash')" class="right-magnet"><i18n>restore</i18n></button>
+			<button ng-click="moveSelection()" class="right-magnet"><i18n>move.first.caps</i18n></button>
 		</div>
 		<div ng-if="zimbra.currentFolder.id && mail.state === 'DRAFT'">
 			<plus class="right-magnet">
 				<a class="button"   target="_blank" ng-href="/zimbra/print#/printMail/[[mail.id]]"><i18n>print</i18n></a>
 				<button ng-click="mail.remove(); openFolder()"><i18n>remove</i18n></button>
+				<button ng-click="moveSelection()" ng-if="!folders.list.includes(zimbra.currentFolder)">
+					<i18n>move.first.caps</i18n>
+				</button>
+				<button ng-click="moveSelection()" ng-if="folders.list.includes(zimbra.currentFolder) && zimbra.currentFolder.folderName !== 'trash'">
+					<i18n>move.inside.folder</i18n>
+				</button>
 			</plus>
 			<button ng-click="editDraft(mail)" class="right-magnet"><i18n>edit</i18n></button>
 		</div>

--- a/zimbra/src/main/resources/public/template/mail-actions/write-mail.html
+++ b/zimbra/src/main/resources/public/template/mail-actions/write-mail.html
@@ -23,6 +23,12 @@
         <div>
             <plus class="right-magnet">
                 <button ng-click="state.newItem.remove(); openFolder()"><i18n>remove</i18n></button>
+                <button ng-click="moveSelection()" ng-if="!folders.list.includes(zimbra.currentFolder)">
+                    <i18n>move.first.caps</i18n>
+                </button>
+                <button ng-click="moveSelection()" ng-if="folders.list.includes(zimbra.currentFolder) && zimbra.currentFolder.folderName !== 'trash'">
+                    <i18n>move.inside.folder</i18n>
+                </button>
             </plus>
             <button class="right-magnet" ng-click="sendMail()" ng-disabled="cantSendMail()">
                 <i18n>submit</i18n>

--- a/zimbra/src/main/resources/public/template/move-mail.html
+++ b/zimbra/src/main/resources/public/template/move-mail.html
@@ -16,13 +16,17 @@
   -->
 
  <!-- Folders - move popup templates -->
+
  <script type="text/ng-template" id="move-folders-content">
+
 	 <a ng-click="destination.folder = folder; moveToFolderClick(folder, obj); folder.selected = !folder.selected"
 		 ng-init="obj = { template: '' }"
 		 ng-class="{ selected: destination.folder.id === folder.id, opened: isOpenedFolder(folder)  }"
 		 class="folder-list-item">
 		<i class="arrow" ng-if="folder.userFolders.all.length"></i>
- 		[[folder.name]]
+		<span ng-if="!folders.list.includes(folder)">[[folder.name]]</span>
+		<span ng-if="folders.list.includes(folder)">[[lang.translate(folder.folderName)]]</span>
+
  	</a>
  	<ul ng-class="{ selected: destination.folder.id === folder.id, closed: isClosedFolder(folder) }"
 		 ng-if="isOpenedFolder(folder)">
@@ -32,15 +36,22 @@
  	</ul>
  </script>
  <script type="text/ng-template" id="move-folders-root">
- 	<ul>
- 		<li ng-repeat="folder in userFolders.all" ng-include="'move-folders-content'"></li>
- 	</ul>
+	 <div ng-if="(!folders.list.includes(zimbra.currentFolder) || zimbra.currentFolder.folderName === 'trash')">
+		 <h3><i18n>messages</i18n></h3>
+		 <ul>
+			 <li ng-repeat="folder in folders.list" ng-include="'move-folders-content'" ng-if="zimbra.currentFolder.id != folder.id"></li>
+		 </ul>
+	 </div>
+
+	 <h3><i18n>user.folders</i18n></h3>
+	 <ul>
+		 <li ng-repeat="folder in userFolders.all" ng-include="'move-folders-content'" ng-if="zimbra.currentFolder.id != folder.id"></li>
+	 </ul>
  </script>
 
 <h2><i18n>mail.move</i18n></h2>
 
 <div class="vertical-spacing-twice horizontal-margin-twice">
-    <h4><i18n>destination.folder</i18n></h4>
     <nav class="vertical vertical-spacing-twice horizontal-margin-twice" ng-include="'move-folders-root'"></nav>
 </div>
 

--- a/zimbra/src/main/resources/public/template/recall-mail.html
+++ b/zimbra/src/main/resources/public/template/recall-mail.html
@@ -23,16 +23,25 @@
         <h5>
             <i18n>mail.return.libelle</i18n>
         </h5>
-        <ul ng-hide="!!mail">
-            <li class="list-return-mail" ng-repeat="mail in zimbra.currentFolder.mails.selection.selectedElements" >
-                [[mail.subject]]
-            </li>
-        </ul>
-        <ul ng-if="!!mail">
-            <li class="list-return-mail">
-                [[mail.subject]]
-            </li>
-        </ul>
+
+        <article>
+            <div class="flex-row align-center">
+                <div class="states"  ng-hide="showRightSide()">
+                    <i class="undo" ng-if="mailToRecall.response" tooltip="you.answered"></i>
+                </div>
+                <div class="flex-all-remains horizontal-margin cell-ellipsis">
+					<span class="strong" ng-repeat="receiver in receivers = (allReceivers(mailToRecall) | limitTo:5 | filter: filterUsers(mailToRecall))">
+						<span>[[mailToRecall.map(receiver).displayName]]</span><span ng-if="$index < (receivers.length - 1) && receivers.length > 1">, </span>
+					</span>
+                    <br>
+                    <span class="small-text">[[mailToRecall.subject]]</span>
+                    <div class="notification-date">
+                        <em class="low-importance right-magnet">[[mailToRecall.notifDate()]]</em>
+                    </div>
+                </div>
+            </div>
+        </article>
+        <span ng-show="containsExternal(mailToRecall.to)">&#9888; <i18n>zimbra.external.user</i18n></span>
     </div>
 
     <div class="vertical-spacing-twice horizontal-margin-twice">
@@ -42,8 +51,7 @@
         <textarea ng-model="comment"></textarea>
     </div>
 
-    <input type="submit" class="right-magnet" ng-hide="!!mail" i18n-value="validate" ng-click="returnMail(zimbra.currentFolder.mails.selection.selectedElements[0].id, comment)"/>
-    <input type="submit" class="right-magnet" ng-if="!!mail" i18n-value="validate" ng-click="returnMail(mail.id, comment)"/>
+    <input type="submit" class="right-magnet" i18n-value="validate" ng-click="recallMail(mailToRecall.id, comment)"/>
     <input type="button" class="right-magnet cancel button" i18n-value="cancel"
            ng-click="lightbox.show = false; template.close('lightbox')"/>
 </div>

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -15,18 +15,21 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-import {$, _, angular, Document, idiom as lang, moment, ng, notify, skin, template, workspace} from "entcore";
+import {$, _, angular, Document, idiom as lang, moment, ng, notify, skin, template} from "entcore";
 import {
     Attachment,
+    AttachmentUploadStatus,
     Group,
     Mail,
     quota,
     RECEIVER_TYPE,
     REGEXLIB,
-    SCREENS, SystemFolder,
+    SCREENS,
+    SystemFolder,
     User,
     UserFolder,
-    Users, Utils,
+    Users,
+    Utils,
     ViewMode,
     Zimbra
 } from "../model";
@@ -1178,7 +1181,7 @@ export let zimbraController = ng.controller("ZimbraController", [
             }
         };
 
-        $scope.uploadAttachments = async (attachments : File[], workspace : boolean) : Promise<void> => {
+        $scope.uploadAttachments = async (attachments: File[], workspace: boolean): Promise<void> => {
             $scope.isFileLoading = true;
             Utils.safeApply($scope);
             const mail: Mail = $scope.state.newItem as Mail;
@@ -1192,14 +1195,16 @@ export let zimbraController = ng.controller("ZimbraController", [
             $scope.displayLightBox.attachment = false;
             Utils.safeApply($scope);
             for (const attachment of mail.attachments) {
-                attachment.uploadStatus == "loading" ? await mail.postAttachments(attachment, workspace) : null;
-                Utils.safeApply($scope);
+                if (attachment.uploadStatus === AttachmentUploadStatus.LOADING) {
+                    await mail.postAttachments(attachment, workspace);
+                    Utils.safeApply($scope);
+                }
             }
             $scope.isFileLoading = false;
             Utils.safeApply($scope);
         }
 
-        $scope.deleteAttachment = function(event, attachment, mail) {
+        $scope.deleteAttachment = function(event, attachment, mail): void {
             mail.deleteAttachment(attachment);
         };
 
@@ -1207,5 +1212,5 @@ export let zimbraController = ng.controller("ZimbraController", [
             $scope.displayLightBox.folder = false;
             Zimbra.instance.currentFolder.deselectAll();
         };
-        $scope.searchText = () => $scope.showRightSide() ? $scope.display.searchSmall : $scope.display.searchLong;
+        $scope.searchText = (): string => $scope.showRightSide() ? $scope.display.searchSmall : $scope.display.searchLong;
     }]);

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -775,10 +775,40 @@ export let zimbraController = ng.controller("ZimbraController", [
             $scope.lightbox.show = true;
             template.open("lightbox", "move-mail");
         };
+        $scope.containsInternal = function(mails: string[]): boolean {
+            for (let mail of mails) {
+                if (!mail.includes("@")){
+                    return true;
+                }
+            }
+            return false;
+        }
+        $scope.containsExternal = function(mails: string[]): boolean {
+            for (let mail of mails) {
+                if (mail.includes("@")){
+                    return true;
+                }
+            }
+            return false;
+        }
+        $scope.getCurrentRecall = function(): Mail {
+            if ($scope.zimbra.currentFolder.mails.selection.selectedElements.length > 0)
+                return $scope.zimbra.currentFolder.mails.selection.selectedElements[0]
+            return $scope.mail;
+        }
+        $scope.isSelectedRecallable = function(): boolean {
+            return $scope.zimbra.currentFolder.mails.selection.selectedElements.length == 1 &&
+                $scope.isRecallable($scope.zimbra.currentFolder.mails.selection.selectedElements[0]);
+        }
+        $scope.isRecallable = function(mail: Mail): boolean {
+            return mail.returned === 'NONE' &&
+                $scope.containsInternal(<any>mail.to);
+        }
 
-        $scope.returnSelection = function() {
+        $scope.toggleRecallView = function() {
             $scope.lightbox.show = true;
-            template.open("lightbox", "return-mail");
+            $scope.mailToRecall = $scope.getCurrentRecall();
+            template.open("lightbox", "recall-mail");
         };
 
         $scope.moveToFolderClick = async (folder, obj) => {
@@ -796,7 +826,7 @@ export let zimbraController = ng.controller("ZimbraController", [
             }, 10);
         };
 
-        $scope.returnMail = async (id, comment) => {
+        $scope.recallMail = async (id: string, comment: string) => {
             $scope.lightbox.show = false;
             template.close("lightbox");
             var data: any = {id: id, comment: comment};

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -187,7 +187,7 @@ export let zimbraController = ng.controller("ZimbraController", [
             if(group.id){
                 group.isGroup = true;
                 $scope.addUser(group);
-            };
+            }
         };
 
         const initFavoriteTo = async (idGroupFavorite:string):Promise<void> => {
@@ -259,6 +259,7 @@ export let zimbraController = ng.controller("ZimbraController", [
                 folderName = (Zimbra.instance.currentFolder as SystemFolder)
                     .folderName;
             }
+            $scope.mail = undefined;
             $scope.state.newItem = new Mail();
             $scope.state.newItem.setMailSignature($scope.getSignature());
             template.open("right-side","right-side");

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -802,7 +802,8 @@ export let zimbraController = ng.controller("ZimbraController", [
         }
         $scope.isRecallable = function(mail: Mail): boolean {
             return mail.returned === 'NONE' &&
-                $scope.containsInternal(<any>mail.to);
+                $scope.containsInternal(<any>mail.to) &&
+                mail.systemFolder === 'OUTBOX';
         }
 
         $scope.toggleRecallView = function() {

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -665,7 +665,7 @@ export let zimbraController = ng.controller("ZimbraController", [
                 removeSelectionFromTrash();
             }
             $scope.state.selectAll = false;
-            $scope.displayLightBox.folder =false;
+            $scope.displayLightBox.folder = false;
             $scope.$apply();
         };
 
@@ -1194,8 +1194,8 @@ export let zimbraController = ng.controller("ZimbraController", [
             mail.deleteAttachment(attachment);
         };
 
-        $scope.cancelDelete = () => {
-            $scope.displayLightBox.folder = true;
+        $scope.cancelDelete = (): void => {
+            $scope.displayLightBox.folder = false;
             Zimbra.instance.currentFolder.deselectAll();
         };
         $scope.searchText = () => $scope.showRightSide() ? $scope.display.searchSmall : $scope.display.searchLong;

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -661,7 +661,7 @@ export let zimbraController = ng.controller("ZimbraController", [
         $scope.removeSelection = async () => {
             await Zimbra.instance.currentFolder.removeSelection();
             $scope.refreshFolders();
-            if ($scope.zimbra.currentFolder.folderName !== 'trash') {
+            if ($scope.zimbra.currentFolder.folderName === 'trash') {
                 removeSelectionFromTrash();
             }
             $scope.state.selectAll = false;

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -841,6 +841,15 @@ export let zimbraController = ng.controller("ZimbraController", [
         $scope.moveMessages = async folderTarget => {
             $scope.lightbox.show = false;
             template.close("lightbox");
+            if ($scope.mail != null) {
+                try {
+                    await $scope.mail.move(folderTarget);
+                    $scope.openFolder();
+                } catch (e) {
+                    console.error("Error while moving mail: + e")
+                }
+                return;
+            }
             let mailIds = [];
             let counter = 0;
             $scope.zimbra.currentFolder.mails.selection.selected.forEach(({id, unread}) => {

--- a/zimbra/src/main/resources/public/ts/model/constantes/codeZimbra.ts
+++ b/zimbra/src/main/resources/public/ts/model/constantes/codeZimbra.ts
@@ -4,6 +4,8 @@ export enum SERVICE {
 }
 
 export enum MAIL {
+    INVALID_REQUEST = "mail.INVALID_REQUEST",
+    ATTACHMENT_TOO_BIG = "mail.ATTACHMENT_TOO_BIG",
     MESSAGE_TOO_BIG = "mail.MESSAGE_TOO_BIG"
 }
 

--- a/zimbra/src/main/resources/public/ts/model/folder.ts
+++ b/zimbra/src/main/resources/public/ts/model/folder.ts
@@ -133,7 +133,7 @@ export class Trash extends SystemFolder {
 
     constructor({unread, count, folders, path}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "trash";
@@ -217,7 +217,7 @@ export class Trash extends SystemFolder {
 export class Inbox extends SystemFolder {
     constructor({unread, count, folders, path}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "inbox";
@@ -249,7 +249,7 @@ export class Draft extends SystemFolder {
 
     constructor({unread, count, folders, path}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "draft";
@@ -302,7 +302,7 @@ export class Draft extends SystemFolder {
 export class Outbox extends SystemFolder {
     constructor({unread, count, folders, path}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "outbox";
@@ -333,7 +333,7 @@ export class Outbox extends SystemFolder {
 export class Spams extends SystemFolder {
     constructor({unread, count, folders, path, id}) {
         super({
-            get: `/zimbra/list?folder=${path}`
+            get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
         this.folderName = "spams";
@@ -464,7 +464,7 @@ export class UserFolders {
     constructor(folders) {
         this.all = [];
         folders.forEach(folder => {
-            const f = new UserFolder({get: `/zimbra/list?folder=${folder.path}`}, folder);
+            const f = new UserFolder({get: `/zimbra/list?folder=${encodeURIComponent(folder.path)}`}, folder);
             f.name = folder.folderName;
             f.id = folder.id;
             f.path = folder.path;

--- a/zimbra/src/main/resources/public/ts/model/folder.ts
+++ b/zimbra/src/main/resources/public/ts/model/folder.ts
@@ -192,20 +192,16 @@ export class Trash extends SystemFolder {
             return;
         }
         await http.put(
-            "/zimbra/restore?" +
-                toFormData({
-                    id: _.pluck(this.mails.selection.selected, "id")
-                })
+            "/zimbra/restore" +
+            { data: { id: this.mails.selection.selected.map(mail => mail.id) } },
         );
         this.mails.removeSelection();
     }
 
     async removeMails() {
         const response = await http.delete(
-            "/zimbra/delete?" +
-                toFormData({
-                    id: _.pluck(this.mails.selection.selected, "id")
-                })
+            "/zimbra/delete",
+            { data: { id: this.mails.selection.selected.map(mail => mail.id) } },
         );
         this.mails.removeSelection();
     }

--- a/zimbra/src/main/resources/public/ts/model/folder.ts
+++ b/zimbra/src/main/resources/public/ts/model/folder.ts
@@ -131,7 +131,7 @@ export abstract class SystemFolder extends Folder {
 export class Trash extends SystemFolder {
     userFolders: Selection<UserFolder> = new Selection<UserFolder>([]);
 
-    constructor({unread, count, folders, path}) {
+    constructor({unread, count, folders, path, id}) {
         super({
             get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
@@ -141,6 +141,7 @@ export class Trash extends SystemFolder {
         this.count = count;
         this.folders = folders;
         this.path = path;
+        this.id = id;
     }
 
     selectAll() {
@@ -215,7 +216,7 @@ export class Trash extends SystemFolder {
 }
 
 export class Inbox extends SystemFolder {
-    constructor({unread, count, folders, path}) {
+    constructor({unread, count, folders, path, id}) {
         super({
             get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
@@ -225,6 +226,7 @@ export class Inbox extends SystemFolder {
         this.count = count;
         this.folders = folders;
         this.path = path;
+        this.id = id;
     }
 
     async sync() {
@@ -247,7 +249,7 @@ export class Inbox extends SystemFolder {
 export class Draft extends SystemFolder {
     totalNb: number;
 
-    constructor({unread, count, folders, path}) {
+    constructor({unread, count, folders, path, id}) {
         super({
             get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
@@ -258,6 +260,7 @@ export class Draft extends SystemFolder {
         this.folders = folders;
         this.path = path;
         this.totalNb = count;
+        this.id = id;
     }
 
     selectAll() {
@@ -300,7 +303,7 @@ export class Draft extends SystemFolder {
 }
 
 export class Outbox extends SystemFolder {
-    constructor({unread, count, folders, path}) {
+    constructor({unread, count, folders, path, id}) {
         super({
             get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
@@ -310,6 +313,7 @@ export class Outbox extends SystemFolder {
         this.count = count;
         this.folders = folders;
         this.path = path;
+        this.id = id;
     }
 
     selectAll() {
@@ -513,6 +517,12 @@ export class SystemFolders {
                     break;
             }
         });
+        this.list.push(this.inbox);
+        this.list.push(this.outbox);
+        this.list.push(this.draft);
+        this.list.push(this.trash);
+        this.list.push(this.spams);
+
     }
 
     async openFolder(folderName) {

--- a/zimbra/src/main/resources/public/ts/model/http.ts
+++ b/zimbra/src/main/resources/public/ts/model/http.ts
@@ -1,5 +1,5 @@
-import {toasts, idiom} from 'entcore';
-import http from 'axios';
+import {idiom, toasts} from 'entcore';
+import http, {AxiosRequestConfig} from 'axios';
 import {SERVICE} from './constantes/codeZimbra';
 
 class Http {
@@ -13,34 +13,30 @@ class Http {
             throw e;
         }
     }
-    async get(url, config?) {
+    async get(url: string, config?: AxiosRequestConfig) {
         try {
-            const response = await http.get(url, config);
-            return response;
+            return http.get(url, config);
         } catch (e) {
            Http.parseError(e);
         }
     }
-    async delete(url, config?) {
+    async delete(url: string, config?: AxiosRequestConfig) {
         try {
-            const response =  await http.delete(url, config);
-            return response;
+            return http.delete(url, config);
         } catch (e) {
             Http.parseError(e);
         }
     }
-    async post(url, data?, config?) {
+    async post(url: string, data?: any, config?: AxiosRequestConfig) {
         try {
-            const response =  await http.post(url, data, config);
-            return response;
+            return http.post(url, data, config);
         } catch (e) {
             Http.parseError(e);
         }
     }
-    async put(url, data?, config?) {
+    async put(url: string, data?: any, config?: AxiosRequestConfig) {
         try {
-            const response =  await http.put(url, data, config);
-            return response;
+            return http.put(url, data, config);
         } catch (e) {
             Http.parseError(e);
         }

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -507,12 +507,14 @@ export class Mail implements Selectable {
                         attach.uploadStatus = AttachmentUploadStatus.LOADED;
                     });
                     this.attachments = this.attachments.concat(attachmentWaiting);
+                    this.newAttachments = null;
                 })
                 .catch((e: AxiosError) => {
                     // remove attachment
                     this.attachments = this.attachments.filter((attachment: Attachment) => {
-                        return attachment.filename !== attachmentToUpload.filename
+                        return attachment.filename !== attachmentToUpload.filename || attachment.id;
                     });
+                    this.newAttachments = null;
                     if (e.response.status === 413) {
                         notify.error(lang.translate("zimbra.message.error.attachment.size2"));
                         return;

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -37,9 +37,16 @@ import {MAIL, SERVICE, QUOTA} from "./constantes";
 import {AxiosError, AxiosResponse} from "axios";
 import {attachmentService} from "../services";
 
+export enum AttachmentUploadStatus {
+    LOADING = "loading",
+    LOADED = "loaded",
+    FAILED = "failed",
+    ABORT = "abort",
+}
+
 export class Attachment {
     file: File;
-    uploadStatus: string;
+    uploadStatus: AttachmentUploadStatus;
     id: string;
     filename: string;
     size: number;
@@ -47,12 +54,13 @@ export class Attachment {
 
     constructor(file: any) {
         this.file = file;
-        this.uploadStatus = "loading";
+        this.uploadStatus = AttachmentUploadStatus.LOADING;
         this.filename = file.metadata ? file.metadata.filename : file.name;
         this.size = file.metadata ? file.metadata.size : file.size;
         this.id = file._id;
     }
 }
+
 export class Mail implements Selectable {
     id: string;
     date: string;
@@ -324,7 +332,7 @@ export class Mail implements Selectable {
             data.to = _.pluck(this.to, "id");
             data.cc = _.pluck(this.cc, "id");
             data.bcc = _.pluck(this.bcc, "id");
-            data.attachments = this.attachments;
+            data.attachments = this.attachments.filter((attachment: Attachment) => attachment.uploadStatus !== AttachmentUploadStatus.LOADING);
 
             var path = "/zimbra/draft";
             if (this.id) {
@@ -402,9 +410,9 @@ export class Mail implements Selectable {
         }
         let response = await http.get("/zimbra/message/" + this.id);
 
-        response.data.attachments.map(attachment => {
+        response.data.attachments.forEach(attachment => {
             attachment.filename = decodeURI((attachment.filename));
-        })
+        });
 
         Mix.extend(this, response.data);
         this.to = this.to.map(user =>
@@ -481,27 +489,33 @@ export class Mail implements Selectable {
         await Zimbra.instance.folders.draft.mails.refresh();
     }
 
-    async postAttachments(attachmentToUpload : Attachment, workspace : boolean) : Promise<void> {
+    async postAttachments(attachmentToUpload: Attachment, workspace: boolean): Promise<void> {
             let post : Promise<AxiosResponse>;
             if (workspace) {
                 post = attachmentService.postAttachmentFromWorkspace(attachmentToUpload, this);
             } else {
-                post = attachmentService.postAttachmentFromComputer(attachmentToUpload, this)
+                post = attachmentService.postAttachmentFromComputer(attachmentToUpload, this);
             }
             const promise: Promise<void> = post
                 .then((response: AxiosResponse) => {
                     const attachmentWaiting : Attachment[] =
-                        this.attachments.filter((attachment : Attachment) =>
-                            attachment.uploadStatus && attachment.uploadStatus == "loading" && attachment != attachmentToUpload);
+                        this.attachments.filter((attachment: Attachment) =>
+                            attachment.uploadStatus && attachment.uploadStatus == AttachmentUploadStatus.LOADING && attachment != attachmentToUpload);
                     this.attachments = response.data.attachments as Attachment[];
                     this.attachments.forEach((attach: Attachment) => {
                         attach.filename = decodeURI(attach.filename);
-                        attach.uploadStatus = "loaded";
+                        attach.uploadStatus = AttachmentUploadStatus.LOADED;
                     });
                     this.attachments = this.attachments.concat(attachmentWaiting);
                 })
                 .catch((e: AxiosError) => {
-                    sendNotificationErrorZimbra(e.response.data.error);
+                    // remove attachment
+                    this.attachments = this.attachments.filter((attachment: Attachment) => {
+                        return attachment.filename !== attachmentToUpload.filename
+                    });
+                    if (e.response && e.response.data && e.response.data.error) {
+                        sendNotificationErrorZimbra(e.response.data.error);
+                    }
                 });
             await Promise.resolve(promise);
     }
@@ -519,9 +533,9 @@ export class Mail implements Selectable {
     async deleteAttachment(attachment) {
         this.attachments.splice(this.attachments.indexOf(attachment), 1);
         const response = await attachmentService.deleteAttachment(attachment, this);
-        this.attachments = response.data.attachments;
-        this.attachments.map(attachment => {
+        this.attachments = response.data.attachments.map(attachment => {
             attachment.filename = decodeURI(attachment.filename);
+            return attachment;
         })
     }
 
@@ -574,6 +588,9 @@ export class Mails {
     }
 
     addRange(arr: Mail[], selectAll: boolean) {
+        if (!arr.length) {
+            return;
+        }
         if (!(arr[0] instanceof Mail)) {
             arr.forEach(d => {
                 var m = Mix.castAs(Mail, d);
@@ -781,9 +798,14 @@ export const sendNotificationErrorZimbra = (errorReturnByZimbra: string): void =
     //TODO extraire la gestion d'erreur du mail
     try {
         console.error("Zimbra returning : ", errorReturnByZimbra);
-        switch (JSON.parse(errorReturnByZimbra).code) {
+        const zimbraError = JSON.parse(errorReturnByZimbra);
+        switch (zimbraError.code) {
             case SERVICE.INVALID_REQUEST:
+            case MAIL.INVALID_REQUEST:
                 notify.error(lang.translate("zimbra.message.error.attachment"));
+                break;
+            case MAIL.ATTACHMENT_TOO_BIG:
+                notify.error(lang.translate("zimbra.message.error.attachment.size").replace("{{maxFileSize}}", zimbraError.maxFileSize));
                 break;
             case MAIL.MESSAGE_TOO_BIG:
                 notify.info(lang.translate("zimbra.message.error.mail.size"));
@@ -792,7 +814,7 @@ export const sendNotificationErrorZimbra = (errorReturnByZimbra: string): void =
                 notify.error(lang.translate("zimbra.quota.info.warning"));
                 break;
             default:
-                notify.error(lang.translate("zimbra.default.intern.error" + errorReturnByZimbra));
+                notify.error(lang.translate("zimbra.default.intern.error") + zimbraError.code);
 
         }
     } catch (error) {

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -651,7 +651,7 @@ export class Mails {
         }
         const response = await http.get(
             "/zimbra/list?folder=" +
-            this.userFolder.path +
+            encodeURIComponent(this.userFolder.path) +
             "&restrain=&page=" +
             data.pageNumber +
             "&unread=" +

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -513,6 +513,10 @@ export class Mail implements Selectable {
                     this.attachments = this.attachments.filter((attachment: Attachment) => {
                         return attachment.filename !== attachmentToUpload.filename
                     });
+                    if (e.response.status === 413) {
+                        notify.error(lang.translate("zimbra.message.error.attachment.size2"));
+                        return;
+                    }
                     if (e.response && e.response.data && e.response.data.error) {
                         sendNotificationErrorZimbra(e.response.data.error);
                     }

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -457,34 +457,35 @@ export class Mail implements Selectable {
             (Zimbra.instance.currentFolder as SystemFolder).folderName !==
             "trash"
         ) {
-            await http.put("/zimbra/trash?id=" + this.id);
+            await http.put("/zimbra/trash", { id: [this.id] });
             Zimbra.instance.currentFolder.mails.refresh();
             Zimbra.instance.folders["trash"].mails.refresh();
         } else {
-            await http.delete("/zimbra/delete?id=" + this.id);
+            await http.delete("/zimbra/delete", { data: { id: [this.id]} });
             Zimbra.instance.folders["trash"].mails.refresh();
         }
     }
 
     async removeFromFolder() {
-        return http.put("move/root?id=" + this.id);
+        return http.put("move/root", { id: [this.id] });
     }
 
     async restore() {
-        await http.put("/zimbra/restore?id=" + this.id);
+        await http.put("/zimbra/restore", { id: [this.id] });
         Zimbra.instance.folders["trash"].mails.refresh();
     }
 
     async move(destinationFolder) {
         await http.put(
-            "move/userfolder/" + destinationFolder.id + "?id=" + this.id
+            "move/userfolder/" + destinationFolder.id,
+            { id: [this.id] },
         );
         await Zimbra.instance.currentFolder.mails.refresh();
         await Zimbra.instance.folders.draft.mails.refresh();
     }
 
     async trash() {
-        await http.put("/zimbra/trash?id=" + this.id);
+        await http.put("/zimbra/trash", { id: [this.id] });
         await Zimbra.instance.currentFolder.mails.refresh();
         await Zimbra.instance.folders.draft.mails.refresh();
     }
@@ -588,8 +589,8 @@ export class Mails {
 
     async removeFromFolder() {
         await http.put(
-            "move/root?" +
-            toFormData({id: _.pluck(this.selection.selected, "id")})
+            "move/root",
+            { id: this.selection.selected.map(mail => mail.id) },
         );
     }
 
@@ -732,8 +733,8 @@ export class Mails {
 
     async toTrash() {
         await http.put(
-            "/zimbra/trash?" +
-            toFormData({id: _.pluck(this.selection.selected, "id")})
+            "/zimbra/trash",
+            { id: this.selection.selected.map(mail => mail.id) },
         );
         this.selection.removeSelection();
     }
@@ -745,9 +746,8 @@ export class Mails {
     async moveSelection(destinationFolder) {
         await http.put(
             "move/userfolder/" +
-            destinationFolder.id +
-            "?" +
-            toFormData({id: _.pluck(this.selection.selected, "id")})
+            destinationFolder.id,
+            { id: this.selection.selected.map(mail => mail.id) },
         );
     }
 

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -814,7 +814,7 @@ export const sendNotificationErrorZimbra = (errorReturnByZimbra: string): void =
                 notify.error(lang.translate("zimbra.message.error.attachment.size").replace("{{maxFileSize}}", zimbraError.maxFileSize));
                 break;
             case MAIL.MESSAGE_TOO_BIG:
-                notify.info(lang.translate("zimbra.message.error.mail.size"));
+                notify.error(lang.translate("zimbra.message.error.attachment.size2"));
                 break;
             case QUOTA.QUOTA_EXCEEDED:
                 notify.error(lang.translate("zimbra.quota.info.warning"));

--- a/zimbra/src/main/resources/public/ts/model/zimbra.ts
+++ b/zimbra/src/main/resources/public/ts/model/zimbra.ts
@@ -122,7 +122,7 @@ export class Zimbra {
                 const parentPath = newFolder.path.replace(`/${newFolder.folderName}`, '');
                 const parentFolder = window.folderMap.get(parentPath.trim() !== '' ? parentPath : '/Inbox');
                 if (parentFolder) {
-                    const f = new UserFolder({get: `/zimbra/list?folder=${newFolder.path}`}, newFolder);
+                    const f = new UserFolder({get: `/zimbra/list?folder=${encodeURIComponent(newFolder.path)}`}, newFolder);
                     if (parentFolder.path === '/Inbox') this.userFolders.all.push(f);
                     else parentFolder.userFolders.all.push(f);
                     f.name = newFolder.folderName;

--- a/zimbra/src/main/resources/sql/009-zimbra-add-mid-to-mail-returned.sql
+++ b/zimbra/src/main/resources/sql/009-zimbra-add-mid-to-mail-returned.sql
@@ -1,0 +1,2 @@
+ALTER TABLE zimbra.mail_returned
+ADD COLUMN mid character varying;

--- a/zimbra/src/test/java/fr/openent/zimbra/helper/ArrayHelperTest.java
+++ b/zimbra/src/test/java/fr/openent/zimbra/helper/ArrayHelperTest.java
@@ -1,0 +1,22 @@
+package fr.openent.zimbra.helper;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(VertxUnitRunner.class)
+public class ArrayHelperTest {
+    @Test
+    public void testSplit (TestContext ctx) {
+        List<String> list = Arrays.asList("a", "b", "c", "d");
+        List<List<String>> batch = ArrayHelper.split(list, 3);
+
+        ctx.assertEquals(2, batch.size());
+        ctx.assertEquals(3, batch.get(0).size());
+        ctx.assertEquals(1, batch.get(1).size());
+    }
+}

--- a/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/AttachmentServiceTest.java
+++ b/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/AttachmentServiceTest.java
@@ -1,0 +1,148 @@
+package fr.openent.zimbra.service.test.impl;
+
+import fr.openent.zimbra.Zimbra;
+import fr.openent.zimbra.core.constants.Field;
+import fr.openent.zimbra.helper.ConfigManager;
+import fr.openent.zimbra.helper.HttpClientHelper;
+import fr.openent.zimbra.service.data.SoapZimbraService;
+import fr.openent.zimbra.service.impl.AttachmentService;
+import fr.openent.zimbra.service.impl.MessageService;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.user.UserInfos;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(VertxUnitRunner.class)
+@PrepareForTest({HttpClientHelper.class, Zimbra.class})
+public class AttachmentServiceTest {
+
+    private Vertx vertx;
+    private AttachmentService attachmentService;
+    private SoapZimbraService soapZimbraService;
+    private MessageService messageService;
+    private HttpClient httpClient;
+
+    @Before
+    public void setUp() throws IllegalAccessException {
+        this.vertx = Mockito.spy(Vertx.vertx());
+        this.soapZimbraService = mock(SoapZimbraService.class);
+        this.messageService = mock(MessageService.class);
+        this.attachmentService = new AttachmentService(soapZimbraService, messageService, Vertx.vertx(), new JsonObject(), null);
+
+        this.httpClient = Mockito.mock(HttpClient.class);
+        mockStatic(HttpClientHelper.class);
+        PowerMockito.when(HttpClientHelper.createHttpClient(Mockito.any())).thenReturn(this.httpClient);
+
+        ConfigManager configManager = mock(ConfigManager.class);
+        mockStatic(Zimbra.class);
+        PowerMockito.field(Zimbra.class, "appConfig").set(Zimbra.class, configManager);
+        PowerMockito.when(Zimbra.appConfig.getZimbraFileUploadMaxSize()).thenReturn(20);
+    }
+
+    @Test
+    public void testAddAttachmentBuffer_too_big(TestContext ctx) {
+        Async async = ctx.async();
+
+        String messageId = "1";
+        UserInfos userInfos = new UserInfos();
+
+        HttpServerRequest httpServerRequest = mock(HttpServerRequest.class);
+        HttpClientRequest httpClientRequest = mock(HttpClientRequest.class);
+        HttpClientResponse httpClientResponse = mock(HttpClientResponse.class);
+        Buffer buffer = mock(Buffer.class);
+        Mockito.when(buffer.toString()).thenReturn("413,null\n");
+
+        Mockito.doAnswer(invocation -> {
+            Handler<Either<String, JsonObject>> response = invocation.getArgument(1);
+            response.handle(new Either.Right<>(new JsonObject().put(Field.AUTH_TOKEN, "token")));
+            return null;
+        }).when(soapZimbraService).getUserAuthToken(Mockito.any(), Mockito.any());
+
+        Mockito.doReturn(200).when(httpClientResponse).statusCode();
+        Mockito.doAnswer(invocation -> {
+            Handler<HttpClientResponse> response = invocation.getArgument(1);
+            response.handle(httpClientResponse);
+            return httpClientRequest;
+        }).when(httpClient).postAbs(Mockito.anyString(), Mockito.any());
+        Mockito.doAnswer(invocation -> httpClientRequest).when(httpClientRequest).setChunked(true);
+        Mockito.doAnswer(invocation -> httpClientRequest).when(httpClientRequest).putHeader(Mockito.anyString(), Mockito.anyString());
+
+        Mockito.doAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(buffer);
+            return null;
+        }).when(httpClientResponse).bodyHandler(Mockito.any());
+
+        this.attachmentService.addAttachmentBuffer(messageId, userInfos, httpServerRequest, result -> {
+            String expected = "{\"code\":\"mail.ATTACHMENT_TOO_BIG\",\"maxFileSize\":20}";
+            ctx.assertEquals(expected, result.left().getValue());
+            async.complete();
+        });
+
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testAddAttachmentBuffer_invalid_request(TestContext ctx) {
+        Async async = ctx.async();
+
+        String messageId = "1";
+        UserInfos userInfos = new UserInfos();
+
+        HttpServerRequest httpServerRequest = mock(HttpServerRequest.class);
+        HttpClientRequest httpClientRequest = mock(HttpClientRequest.class);
+        HttpClientResponse httpClientResponse = mock(HttpClientResponse.class);
+        Buffer buffer = mock(Buffer.class);
+        Mockito.when(buffer.toString()).thenReturn("400,null\n");
+
+        Mockito.doAnswer(invocation -> {
+            Handler<Either<String, JsonObject>> response = invocation.getArgument(1);
+            response.handle(new Either.Right<>(new JsonObject().put(Field.AUTH_TOKEN, "token")));
+            return null;
+        }).when(soapZimbraService).getUserAuthToken(Mockito.any(), Mockito.any());
+
+        Mockito.doReturn(200).when(httpClientResponse).statusCode();
+        Mockito.doAnswer(invocation -> {
+            Handler<HttpClientResponse> response = invocation.getArgument(1);
+            response.handle(httpClientResponse);
+            return httpClientRequest;
+        }).when(httpClient).postAbs(Mockito.anyString(), Mockito.any());
+        Mockito.doAnswer(invocation -> httpClientRequest).when(httpClientRequest).setChunked(true);
+        Mockito.doAnswer(invocation -> httpClientRequest).when(httpClientRequest).putHeader(Mockito.anyString(), Mockito.anyString());
+
+        Mockito.doAnswer(invocation -> {
+            Handler<Buffer> bodyHandler = invocation.getArgument(0);
+            bodyHandler.handle(buffer);
+            return null;
+        }).when(httpClientResponse).bodyHandler(Mockito.any());
+
+        this.attachmentService.addAttachmentBuffer(messageId, userInfos, httpServerRequest, result -> {
+            String expected = "{\"code\":\"mail.INVALID_REQUEST\"}";
+            ctx.assertEquals(expected, result.left().getValue());
+            async.complete();
+        });
+
+        async.awaitSuccess(10000);
+    }
+}

--- a/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/MessageServiceTest.java
+++ b/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/MessageServiceTest.java
@@ -1,30 +1,45 @@
 package fr.openent.zimbra.service.test.impl;
 
+import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.helper.ServiceManager;
 import fr.openent.zimbra.model.constant.FrontConstants;
 import fr.openent.zimbra.model.constant.ZimbraConstants;
 import fr.openent.zimbra.service.impl.MessageService;
+import fr.openent.zimbra.service.impl.UserService;
+import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import org.powermock.reflect.Whitebox;
 import java.util.HashMap;
+import java.util.List;
 
-@RunWith(VertxUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(VertxUnitRunner.class)
+@PrepareForTest({MessageService.class, UserService.class})
 public class MessageServiceTest {
 
     private MessageService messageService;
+    private UserService userService;
 
     @Before
     public void setUp() {
-        ServiceManager serviceManager = ServiceManager.init(Vertx.vertx(), Vertx.vertx().eventBus(), "", null);
-        this.messageService = serviceManager.getMessageService();
+        this.userService = Mockito.mock(UserService.class);
+        PowerMockito.spy(MessageService.class);
+        this.messageService = PowerMockito.spy(new MessageService(null, null, null, userService, null));
     }
 
     @Test
@@ -55,4 +70,45 @@ public class MessageServiceTest {
                         ctx.assertNull(result.getBoolean(FrontConstants.IS_REPORT_REQUIRED)));
     }
 
+    @Test
+    public void testGetDisplayNames(TestContext ctx) throws Exception {
+        JsonArray frontMessages = new JsonArray();
+        JsonObject frontMessage = new JsonObject();
+        frontMessages.add(frontMessage);
+        JsonArray displayNames = new JsonArray();
+        displayNames.add(new JsonArray().add("a6fc1dbf-5df5-4fd1-a64a-d65d53179f05").add(""));
+        displayNames.add(new JsonArray().add("email@email.com").add(""));
+        displayNames.add(new JsonArray().add("90391c10-996e-444e-8308-9deb921ce51d").add(""));
+        displayNames.add(new JsonArray().add("email@email.com"));
+        frontMessage.put(FrontConstants.MAIL_DISPLAYNAMES, displayNames);
+
+        List<JsonArray> getDisplayNames = Whitebox.invokeMethod(messageService, "getDisplayNames", frontMessages);
+        ctx.assertEquals(2, getDisplayNames.size());
+    }
+
+    @Test
+    public void testRetrieveUsername(TestContext ctx) throws Exception {
+        Async async = ctx.async();
+
+        PowerMockito.doAnswer((Answer<HashMap<String, String>>) invocation -> {
+            Handler<Either<String, JsonArray>> handler = invocation.getArgument(2);
+            JsonArray userIds = new JsonArray();
+            userIds.add(new JsonObject().put(Field.ID, "5eba594c-0d88-4287-af0e-b57e4d981aec").put(Field.USERNAME, "user1"));
+            userIds.add(new JsonObject().put(Field.ID, "2aaad182-659b-4f4f-bb1c-001daf954cd6").put(Field.USERNAME, "user2"));
+            handler.handle(new Either.Right<>(userIds));
+            return null;
+        }).when(userService).getUsers(Mockito.any(), Mockito.any(), Mockito.any());
+
+        Future<HashMap<String, String>> future = Whitebox.invokeMethod(messageService, "retrieveUsernames", Mockito.any());
+        future.onSuccess(res -> {
+            ctx.assertEquals(2, res.size());
+            ctx.assertEquals("user1", res.get("5eba594c-0d88-4287-af0e-b57e4d981aec"));
+            ctx.assertEquals("user2", res.get("2aaad182-659b-4f4f-bb1c-001daf954cd6"));
+            async.complete();
+        }).onFailure(e -> {
+            ctx.fail();
+        });
+
+        async.awaitSuccess(10000);
+    }
 }

--- a/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/SqlDbMailServiceTest.java
+++ b/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/SqlDbMailServiceTest.java
@@ -1,0 +1,75 @@
+package fr.openent.zimbra.service.test.impl;
+
+import fr.openent.zimbra.service.data.SqlDbMailService;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.sql.Sql;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldSetter;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(VertxUnitRunner.class)
+@PrepareForTest({Sql.class})
+public class SqlDbMailServiceTest {
+
+    private SqlDbMailService sqlDbMailService;
+    private final Sql sql = PowerMockito.mock(Sql.class);
+
+    @Before
+    public void setUp() throws NoSuchFieldException {
+        this.sqlDbMailService = new SqlDbMailService("test");
+        FieldSetter.setField(sqlDbMailService, sqlDbMailService.getClass().getDeclaredField("sql"), sql);
+        FieldSetter.setField(sqlDbMailService, sqlDbMailService.getClass().getDeclaredField("returnedMailTable"), "schema.mail_returned");
+    }
+
+    @Test
+    public void testGetMailReturnedByIds_empty_ids(TestContext ctx) {
+        List<String> emptyList = new ArrayList<>();
+        Async async = ctx.async();
+
+        this.sqlDbMailService.getMailReturnedByIds(emptyList, result -> {
+            JsonArray expected = new JsonArray();
+            ctx.assertEquals(expected, result.right().getValue());
+            async.complete();
+        });
+
+        async.awaitSuccess(10000);
+    }
+
+    @Test
+    public void testGetMailReturnedByIds_not_empty(TestContext ctx) {
+        Async async = ctx.async();
+        List<String> userIds = new ArrayList<>();
+        userIds.add("1");
+        String expectedQuery = "SELECT * FROM schema.mail_returned WHERE id IN (?)";
+        JsonArray expectedParams = new JsonArray().add(1);
+
+        Mockito.doAnswer((Answer<Void>) invocation -> {
+            String queryResult = invocation.getArgument(0);
+            JsonArray paramsResult = invocation.getArgument(1);
+            ctx.assertEquals(expectedQuery, queryResult);
+            ctx.assertEquals(expectedParams.toString(), paramsResult.toString());
+            async.complete();
+            return null;
+        }).when(sql).prepared(Mockito.anyString(), Mockito.any(JsonArray.class), Mockito.any(Handler.class));
+
+        this.sqlDbMailService.getMailReturnedByIds(userIds, null);
+
+        async.awaitSuccess(10000);
+    }
+}


### PR DESCRIPTION
## Describe your changes

- Created a new method to move messages in Zimbra with batch size of 100
- Created a new method to delete messages in Zimbra with batch size of 100
- Use body to pass id (instead of query params) for this requests : 
  - PUT /zimbra/trash
  - PUT /zimbra/restore
  - DELETE /zimbra/delete
  - PUT /zimbra/move/userfolder/:folderId
  - PUT /zimbra/move/root
> We keep getting param id in URL until the mobile app conforms to it.
> Doc updated : https://confluence.support-ent.fr/display/ZIM/Messages
- Updated front for this api calls

## Checklist tests

- [x] Empty trash with more than 100 mails
- [x] Move one or multiple mails in a folder
- [x] Move one or multiple mails in trash

## Issue ticket number and link

[JIRA#MZI-177](https://jira.support-ent.fr/browse/MZI-177)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)