### PR TITLE
fix(recall): MZI-143 change move button scope for spams

### DIFF
--- a/zimbra/src/main/resources/public/template/folders-templates/toaster.html
+++ b/zimbra/src/main/resources/public/template/folders-templates/toaster.html
@@ -21,10 +21,10 @@
             <button ng-click="showConfirm()" ng-if="zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length">
                 <i18n>remove</i18n>
             </button>
-            <button ng-click="moveSelection()" ng-if="(zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length) && (zimbra.currentFolder.folderName === 'trash' || !folders.list.includes(zimbra.currentFolder))">
+            <button ng-click="moveSelection()" ng-if="(zimbra.currentFolder.mails.selection.length || zimbra.currentFolder.userFolders.selected.length) && (zimbra.currentFolder.folderName === 'trash' || zimbra.currentFolder.folderName === 'spams' || !folders.list.includes(zimbra.currentFolder))">
                 <i18n>move.first.caps</i18n>
             </button>
-                <button ng-click="moveSelection()" ng-if="zimbra.currentFolder.mails.selection.length && folders.list.includes(zimbra.currentFolder) && zimbra.currentFolder.folderName !== 'trash'">
+                <button ng-click="moveSelection()" ng-if="zimbra.currentFolder.mails.selection.length && folders.list.includes(zimbra.currentFolder) && zimbra.currentFolder.folderName !== 'trash' && zimbra.currentFolder.folderName !== 'spams'">
                 <i18n>move.inside.folder</i18n>
             </button>
             <button ng-click="toggleRecallView()"

--- a/zimbra/src/main/resources/public/template/move-mail.html
+++ b/zimbra/src/main/resources/public/template/move-mail.html
@@ -36,7 +36,7 @@
  	</ul>
  </script>
  <script type="text/ng-template" id="move-folders-root">
-	 <div ng-if="(!folders.list.includes(zimbra.currentFolder) || zimbra.currentFolder.folderName === 'trash')">
+	 <div ng-if="(!folders.list.includes(zimbra.currentFolder) || zimbra.currentFolder.folderName === 'trash' || zimbra.currentFolder.folderName === 'spams')">
 		 <h3><i18n>messages</i18n></h3>
 		 <ul>
 			 <li ng-repeat="folder in folders.list" ng-include="'move-folders-content'" ng-if="zimbra.currentFolder.id != folder.id"></li>


### PR DESCRIPTION
## Describe your changes
Updqte move button for trash folder. It is now possible to move messages in trash folder in basic zimbra folder.
## Checklist tests
- [x] Move from spams to any folder
## Issue ticket number and link
[ MZI-143 ]
https://jira.support-ent.fr/browse/MZI-143
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)