### PR TITLE
feat(recall): #MZI-198 integrate recall task to queue logic

### DIFF
--- a/zimbra/src/main/java/fr/openent/zimbra/Zimbra.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/Zimbra.java
@@ -75,11 +75,6 @@ public class Zimbra extends BaseServer {
         setRepositoryEvents(new ZimbraRepositoryEvents());
 
         // Workers
-//        vertx.deployVerticle(RecallMailWorker.class.getName(), new DeploymentOptions().setWorker(true).setConfig(config));
-
-        // Recall cron
-        RecallMailCron recallMailCron = new RecallMailCron(recallMailService, vertx.eventBus());
-//        new CronTrigger(vertx, appConfig.getRecallCron()).schedule(recallMailCron);
         vertx.deployVerticle(RecallMailWorker.class.getName(), new DeploymentOptions().setWorker(true).setConfig(config));
         vertx.deployVerticle(ICalRequestWorker.class.getName(), new DeploymentOptions().setWorker(true).setConfig(config));
 
@@ -87,7 +82,7 @@ public class Zimbra extends BaseServer {
             SynchroTask syncLauncherTask = new SynchroTask(vertx.eventBus(), BusConstants.ACTION_STARTSYNCHRO);
             new CronTrigger(vertx, appConfig.getSynchroCronDate()).schedule(syncLauncherTask);
             new CronTrigger(vertx, appConfig.getZimbraICalCron()).schedule(new ICalRequestCron(vertx.eventBus()));
-//            RecallMailCron recallMailCron = new RecallMailCron(recallMailService, vertx.eventBus());
+            RecallMailCron recallMailCron = new RecallMailCron(recallMailService, vertx.eventBus());
             new CronTrigger(vertx, appConfig.getZimbraRecallCron()).schedule(recallMailCron);
             log.info("Cron launched with date : " + appConfig.getSynchroCronDate());
             returnedMailService.deleteMailsProgress(event -> {

--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -30,6 +30,7 @@ import fr.openent.zimbra.helper.ServiceManager;
 import fr.openent.zimbra.model.action.Action;
 import fr.openent.zimbra.model.constant.FrontConstants;
 import fr.openent.zimbra.model.constant.ModuleConstants;
+import fr.openent.zimbra.model.message.RecallMail;
 import fr.openent.zimbra.model.task.ICalTask;
 import fr.openent.zimbra.security.ExpertAccess;
 import fr.openent.zimbra.security.WorkflowActionUtils;
@@ -73,6 +74,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static fr.openent.zimbra.model.constant.FrontConstants.MESSAGE_ID;
 import static fr.openent.zimbra.model.constant.ZimbraConstants.ZIMBRA_MAIL;
@@ -403,7 +405,7 @@ public class ZimbraController extends BaseController {
                                                 "fail to create recall mail: %s",
                                         this.getClass().getSimpleName(), err.getMessage());
                                 log.error(errMessage);
-                                badRequest(request);
+                                badRequest(request, err.getMessage());
                             });
                 });
             });
@@ -416,7 +418,52 @@ public class ZimbraController extends BaseController {
         }
     }
 
+    @Put("/recall/accept")
+    @SecuredAction(value = "zimbra.recall.accept", type = ActionType.WORKFLOW)
+    public void acceptRecall(HttpServerRequest request) {
+        try {
+            int recallId = Integer.parseInt(request.params().get(Field.ID));
+            recallMailService.acceptRecall(recallId)
+                    .onSuccess(res -> renderJson(request, new JsonObject().put(Field.STATUS, Field.SUCCESS)))
+                    .onFailure(err -> {
+                        String errMessage = String.format("[Zimbra@%s::acceptRecall]:  " +
+                                        "fail to accept recall: %s",
+                                this.getClass().getSimpleName(), err.getMessage());
+                        log.error(errMessage);
+                        badRequest(request, err.getMessage());
+                    });
+        } catch (NumberFormatException e) {
+            String errMessage = String.format("[Zimbra@%s::acceptRecall]:  " +
+                            "fail to accept recall: %s",
+                    this.getClass().getSimpleName(), e.getMessage());
+            log.error(errMessage);
+            badRequest(request);
+        }
+    }
 
+    @Get("/recall/list")
+    @SecuredAction(value = "zimbra.recall.list", type = ActionType.WORKFLOW)
+    public void listRecall(HttpServerRequest request) {
+        try {
+            String structureId = request.params().get(Field.STRUCTUREID);
+            recallMailService.getRecallMailsForOneStructure(structureId)
+                    .onSuccess(mails -> renderJson(request, new JsonObject()
+                            .put(Field.RECALLMAILS, new JsonArray(mails.stream().map(RecallMail::generateDataForFront).collect(Collectors.toList())))))
+                    .onFailure(err -> {
+                        String errMessage = String.format("[Zimbra@%s::acceptRecall]:  " +
+                                        "fail to accept recall: %s",
+                                this.getClass().getSimpleName(), err.getMessage());
+                        log.error(errMessage);
+                        badRequest(request);
+                    });
+        } catch (NumberFormatException e) {
+            String errMessage = String.format("[Zimbra@%s::acceptRecall]:  " +
+                            "fail to accept recall: %s",
+                    this.getClass().getSimpleName(), e.getMessage());
+            log.error(errMessage);
+            badRequest(request);
+        }
+    }
 
     @Get("root-folder")
     @SecuredAction(value = "", type = ActionType.AUTHENTICATED)
@@ -470,7 +517,10 @@ public class ZimbraController extends BaseController {
                         if (!folder.equals("/Sent")) {
                             renderJson(request, event.right().getValue());
                         } else {
-//                            returnedMailService.renderReturnedMail(request, user, event);
+                            recallMailService.renderRecallMails(user, event.right().getValue())
+                                    .onSuccess(res -> renderJson(request, res))
+                                    .onFailure(err -> renderJson(request, event.right().getValue()));
+
                         }
                     } else {
                         log.error(String.format("[Zimbra@ZimbraController::listMessages] failed to listMessages: %s", event.left().getValue()));

--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -405,7 +405,7 @@ public class ZimbraController extends BaseController {
                                                 "fail to create recall mail: %s",
                                         this.getClass().getSimpleName(), err.getMessage());
                                 log.error(errMessage);
-                                badRequest(request, err.getMessage());
+                                badRequest(request);
                             });
                 });
             });
@@ -418,7 +418,7 @@ public class ZimbraController extends BaseController {
         }
     }
 
-    @Put("/recall/accept")
+    @Put("/recall/:id/accept")
     @SecuredAction(value = "zimbra.recall.accept", type = ActionType.WORKFLOW)
     public void acceptRecall(HttpServerRequest request) {
         try {
@@ -430,7 +430,7 @@ public class ZimbraController extends BaseController {
                                         "fail to accept recall: %s",
                                 this.getClass().getSimpleName(), err.getMessage());
                         log.error(errMessage);
-                        badRequest(request, err.getMessage());
+                        badRequest(request);
                     });
         } catch (NumberFormatException e) {
             String errMessage = String.format("[Zimbra@%s::acceptRecall]:  " +

--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -422,7 +422,7 @@ public class ZimbraController extends BaseController {
     @SecuredAction(value = "zimbra.recall.accept", type = ActionType.WORKFLOW)
     public void acceptRecall(HttpServerRequest request) {
         try {
-            int recallId = Integer.parseInt(request.params().get(Field.ID));
+            int recallId = Integer.parseInt(request.getParam(Field.ID));
             recallMailService.acceptRecall(recallId)
                     .onSuccess(res -> renderJson(request, new JsonObject().put(Field.STATUS, Field.SUCCESS)))
                     .onFailure(err -> {
@@ -441,11 +441,11 @@ public class ZimbraController extends BaseController {
         }
     }
 
-    @Get("/recall/list")
+    @Get("/recall/structure/:structureid/list")
     @SecuredAction(value = "zimbra.recall.list", type = ActionType.WORKFLOW)
     public void listRecall(HttpServerRequest request) {
         try {
-            String structureId = request.params().get(Field.STRUCTUREID);
+            String structureId = request.getParam(Field.STRUCTUREID);
             recallMailService.getRecallMailsForOneStructure(structureId)
                     .onSuccess(mails -> renderJson(request, new JsonObject()
                             .put(Field.RECALLMAILS, new JsonArray(mails.stream().map(RecallMail::generateDataForFront).collect(Collectors.toList())))))

--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -450,14 +450,14 @@ public class ZimbraController extends BaseController {
                     .onSuccess(mails -> renderJson(request, new JsonObject()
                             .put(Field.RECALLMAILS, new JsonArray(mails.stream().map(RecallMail::generateDataForFront).collect(Collectors.toList())))))
                     .onFailure(err -> {
-                        String errMessage = String.format("[Zimbra@%s::acceptRecall]:  " +
+                        String errMessage = String.format("[Zimbra@%s::listRecall]:  " +
                                         "fail to accept recall: %s",
                                 this.getClass().getSimpleName(), err.getMessage());
                         log.error(errMessage);
                         badRequest(request);
                     });
         } catch (NumberFormatException e) {
-            String errMessage = String.format("[Zimbra@%s::acceptRecall]:  " +
+            String errMessage = String.format("[Zimbra@%s::listRecall]:  " +
                             "fail to accept recall: %s",
                     this.getClass().getSimpleName(), e.getMessage());
             log.error(errMessage);

--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -7,22 +7,35 @@ public class Field {
         throw new IllegalStateException("Utility class");
     }
 
+
+    public static final String RECIPIENT_ADDRESS = "recipient_address";
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String CONTENT_DISPOSITION = "Content-Disposition";
     public static final String COOKIE = "Cookie";
+    public static final String CAPITAL_WAITING = "WAITING";
     public static final String AUTH_TOKEN = "authToken";
     public static final String NAME = "name";
+    public static final String RETURNED = "returned";
     public static final String ERROR = "error";
+    public static final String CAPITAL_ERROR = "ERROR";
+    public static final String CAPITAL_REMOVED = "REMOVED";
+    public static final String CAPITAL_PROGRESS = "PROGRESS";
     public static final String STATUS = "status";
+    public static final String STATUT = "statut";
     public static final String SUCCESS = "success";
     public static final String ID = "id";
+    public static final String MID = "mid";
     public static final String IDS = "ids";
+    public static final String TOTAL = "total";
+    public static final String MAILID = "mailId";
+    public static final String SUBJECT = "subject";
     public static final String SIZE = "size";
     public static final String MESSAGE = "message";
     public static final String OK = "ok";
     public static final String KO = "ko";
     public static final String RESULT = "result";
     public static final String RESULTS = "results";
+    public static final String OBJECT = "object";
 
     public static final String APP = "zimbra";
     public static final String FALSE = "false";
@@ -66,6 +79,7 @@ public class Field {
     public static final String TASK_ID = "task_id";
     public static final String TASK_STATUS = "task_status";
     public static final String RECALL_MAIL_ID = "recall_mail_id";
+    public static final String RECALL_MAIL = "recall_mail";
     public static final String MAIL_DATE = "mail_date";
     public static final String RECEIVER_ID = "receiver_id";
     public static final String RECEIVERS_ID = "receivers_id";
@@ -73,6 +87,7 @@ public class Field {
     public static final String JSNS = "jsns";
     public static final String BODY_LOWER_CASE = "body";
     public static final String MESSAGE_ID = "message_id";
+    public static final String LOCAL_MAIL_ID = "local_mail_id";
     public static final String ZIMBRA = "zimbra";
     public static final String RECEIVERID = "receiverId";
     public static final String TASKS = "tasks";
@@ -83,8 +98,10 @@ public class Field {
     public static final String STRUCTURES = "structures";
     public static final String STRUCTURE = "structure";
     public static final String ADMLS = "admls";
+    public static final String MAIL = "mail";
     public static final String STRUCTURESID = "structuresId";
-    public static final String OBJECT = "object";
+    public static final String RECALLMAILS = "recallMails";
+    public static final String STRUCTUREID = "structureId";
 
     public static final String PLATFORM = "platform";
     public static final String ZIMBRAUC = "Zimbra";

--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -101,7 +101,7 @@ public class Field {
     public static final String MAIL = "mail";
     public static final String STRUCTURESID = "structuresId";
     public static final String RECALLMAILS = "recallMails";
-    public static final String STRUCTUREID = "structureId";
+    public static final String STRUCTUREID = "structureid";
 
     public static final String PLATFORM = "platform";
     public static final String ZIMBRAUC = "Zimbra";

--- a/zimbra/src/main/java/fr/openent/zimbra/core/enums/ErrorEnum.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/enums/ErrorEnum.java
@@ -15,6 +15,7 @@ public enum ErrorEnum {
     ERROR_QUEUE_TASK("zimbra.error.queue.task"),
     ERROR_TASK_RETRIEVE("zimbra.error.task.retrieve"),
     ERROR_RECALL_RETRIEVE("zimbra.error.retrieve.recalls"),
+    ERROR_ACTION_UPDATE("zimbra.error.update.action"),
     ERROR_FETCHING_TASK("zimbra.error.fetching.task"),
     ERROR_NO_SUCH_MESSAGE("zimbra.recall.no.such.message"),
     ERROR_FETCHING_ACTION("zimbra.error.fetching.action"),

--- a/zimbra/src/main/java/fr/openent/zimbra/core/enums/ErrorEnum.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/enums/ErrorEnum.java
@@ -14,17 +14,23 @@ public enum ErrorEnum {
     ERROR_TASK_MODEL("zimbra.error.task.model"),
     ERROR_QUEUE_TASK("zimbra.error.queue.task"),
     ERROR_TASK_RETRIEVE("zimbra.error.task.retrieve"),
+    ERROR_RECALL_RETRIEVE("zimbra.error.retrieve.recalls"),
     ERROR_FETCHING_TASK("zimbra.error.fetching.task"),
+    ERROR_NO_SUCH_MESSAGE("zimbra.recall.no.such.message"),
     ERROR_FETCHING_ACTION("zimbra.error.fetching.action"),
     ERROR_FETCHING_STRUCTURE("zimbra.error.fetching.structures"),
+    FAIL_ACCEPT_RECALL("fail.acept.recall"),
     ERROR_FETCHING_ADML("zimbra.error.fetching.adml"),
     ERROR_RETRIEVING_ACTION("zimbra.error.retrieving.action"),
+    ERROR_DELETING_MAIL("zimbra.error.deleting.mail"),
     ERROR_EDITING_TASK("zimbra.error.editing.task"),
+    ERROR_FETCHING_MODEL("zimbra.fetching.model"),
     ERROR_UPDATING_TASK("zimbra.error.updating.task"),
     ACTION_DOES_NOT_EXIST("action.does.not.exit"),
     ERROR_NOTIFY_CALENDAR("fail.to.notify.calendar.module"),
     USER_NOT_DEFINED("user.not.defined"),
     ERROR_RETRIEVING_ICAL("error.retrieving.ical"),
+    ERROR_CREATING_LOGS("error.creating.logs"),
     NO_MAIL_TO_RECALL("no.mail.to.recall");
 
     private final String errorEnum;

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/PromiseHelper.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/PromiseHelper.java
@@ -17,7 +17,7 @@ public class PromiseHelper {
         throw new IllegalStateException("Utility PromiseHelper class");
     }
 
-    public static Handler<Either<String, JsonObject>> handlerJsonObject(Promise<JsonObject> promise) {
+    public static <T> Handler<Either<String, T>> handlerJsonObject(Promise<T> promise) {
         return event -> {
             if (event.isRight()) {
                 promise.complete(event.right().getValue());

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/ServiceManager.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/ServiceManager.java
@@ -125,7 +125,7 @@ public class ServiceManager {
             this.synchroAddressBookService = new SynchroAddressBookService(sqlSynchroService);
             this.userService = new UserService(soapService, synchroUserService, dbMailServiceApp,
                     synchroAddressBookService, addressBookService, eb);
-            this.sqlRecallTaskService = new SqlRecallTaskService(config.getDbSchema());
+            this.sqlRecallTaskService = new SqlRecallTaskService(config.getDbSchema(), config.getZimbraRecallWorkerMaxQueue());
             this.sqlICalTaskService = new SqlICalTaskService(config.getDbSchema());
             this.sqlActionService = new SqlActionService(config.getDbSchema());
             this.sqlRecallMailService = new SqlRecallMailService(config.getDbSchema());
@@ -151,7 +151,7 @@ public class ServiceManager {
         this.frontPageService = new FrontPageService(folderService, userService);
         this.returnedMailService = new ReturnedMailService(new DbMailServiceFactory(vertx, sqlSynchroService).getDbMailService("postgres"), messageService, userService, notificationService, eb);
         this.structureService = new StructureServiceImpl(neoService);
-        this.recallMailService = new RecallMailServiceImpl(sqlRecallMailService, neoService, recallQueueService, notificationService, structureService, recipientService);
+        this.recallMailService = new RecallMailServiceImpl(sqlRecallMailService, messageService, recallQueueService, notificationService, structureService, recipientService);
 
         this.synchroLauncher = new SynchroLauncher(synchroUserService, sqlSynchroService);
         this.synchroService = new SynchroService(sqlSynchroService, synchroLauncher);

--- a/zimbra/src/main/java/fr/openent/zimbra/model/action/Action.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/action/Action.java
@@ -5,12 +5,9 @@ import fr.openent.zimbra.core.enums.ActionType;
 import fr.openent.zimbra.model.task.Task;
 import fr.openent.zimbra.utils.DateUtils;
 import io.vertx.core.json.JsonObject;
-
-import java.text.SimpleDateFormat;
-import java.time.Instant;
 import java.util.*;
 
-public class Action<T extends Task> {
+public class Action<T extends Task<T>> {
     protected long id;
     protected UUID userId;
     protected Date createdAt;
@@ -34,7 +31,7 @@ public class Action<T extends Task> {
         this.tasks = new HashSet<>();
     }
     private static boolean JSONContainsActionData (JsonObject actionData) {
-        return  actionData.containsKey(Field.ACTION_ID) &&
+        return  actionData.containsKey(Field.ID) &&
                 actionData.containsKey(Field.USER_ID) &&
                 actionData.containsKey(Field.CREATED_AT) &&
                 actionData.containsKey(Field.TYPE) &&
@@ -45,7 +42,7 @@ public class Action<T extends Task> {
         if (!JSONContainsActionData(actionData)) {
             throw new Exception(String.format("[Zimbra@%s::Action] Json does not match Action model", Action.class));
         }
-        long id = actionData.getInteger(Field.ACTION_ID);
+        long id = actionData.getInteger(Field.ID);
         try {
             UUID userId = UUID.fromString(actionData.getString(Field.USER_ID));
             Date created_at = DateUtils.parseDate(actionData.getString(Field.CREATED_AT), DateUtils.DATE_FORMAT_SQL);

--- a/zimbra/src/main/java/fr/openent/zimbra/model/message/Message.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/message/Message.java
@@ -1,5 +1,6 @@
 package fr.openent.zimbra.model.message;
 
+import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.helper.RecipientHelper;
 import fr.openent.zimbra.helper.ZimbraFlags;
 import fr.openent.zimbra.model.constant.FrontConstants;
@@ -88,6 +89,13 @@ public class Message {
         return fromZimbra(zimbraData, false);
     }
 
+    public Message(String id, String subject, String mailId, Long date) {
+        this.id = id;
+        this.subject = subject;
+        this.mailId = mailId;
+        this.date = date;
+    }
+
     public static Message fromZimbra(JsonObject zimbraData, boolean fromConv) throws IllegalArgumentException {
         Message message = new Message();
         message.id = zimbraData.getString(MSG_ID, "");
@@ -142,5 +150,12 @@ public class Message {
 
     public Map<String, Recipient> getUserMapping() {
         return userMapping;
+    }
+
+    public JsonObject toJson() {
+        return new JsonObject()
+                .put(Field.MAILID, mailId)
+                .put(Field.SUBJECT, subject)
+                .put(Field.MAIL_DATE, date);
     }
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/model/message/RecallMail.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/message/RecallMail.java
@@ -1,17 +1,30 @@
 package fr.openent.zimbra.model.message;
 
+import fr.openent.zimbra.core.constants.Field;
+import fr.openent.zimbra.core.enums.TaskStatus;
 import fr.openent.zimbra.model.action.Action;
 import fr.openent.zimbra.model.task.RecallTask;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class RecallMail {
     private int recallId;
     private Message message;
-    private  String comment;
+    private String comment;
+    private String senderEmail;
     private Action<RecallTask> action;
 
     public RecallMail(int recallId, Message message) {
         this.recallId = recallId;
         this.message = message;
+    }
+
+    public RecallMail(int recallId, Message message, String senderEmail) {
+        this(recallId, message);
+        this.senderEmail = senderEmail;
     }
 
     public RecallMail(int recallId, Message message, Action<RecallTask> action, String comment) {
@@ -38,5 +51,25 @@ public class RecallMail {
 
     public void setId(int recallId) {
         this.recallId = recallId;
+    }
+
+    public String getSenderEmail() {
+        return senderEmail;
+    }
+
+    public JsonObject generateDataForFront() {
+        JsonObject messageJson = message != null ? message.toJson() : null;
+        JsonObject tasks = new JsonObject();
+        if (action != null) {
+            tasks
+                    .put(TaskStatus.FINISHED.method(), action.getTasks().stream().filter(task -> task.getStatus() == TaskStatus.FINISHED).count())
+                    .put(TaskStatus.ERROR.method(), action.getTasks().stream().filter(task -> task.getStatus() == TaskStatus.ERROR).count())
+                    .put(Field.TOTAL, action.getTasks().size());
+        }
+        return new JsonObject()
+                .put(Field.RECALL_MAIL_ID, recallId)
+                .put(Field.COMMENT, comment)
+                .put(Field.MESSAGE, messageJson)
+                .put(Field.ACTION, tasks);
     }
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/model/soap/SoapMessageHelper.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/soap/SoapMessageHelper.java
@@ -1,5 +1,6 @@
 package fr.openent.zimbra.model.soap;
 
+import fr.openent.zimbra.core.enums.ErrorEnum;
 import fr.openent.zimbra.model.constant.SoapConstants;
 import fr.openent.zimbra.model.message.Message;
 import io.vertx.core.AsyncResult;
@@ -62,6 +63,7 @@ public class SoapMessageHelper {
                                 "error while getting mail from zimbra: %s",
                         SoapMessageHelper.class.getSimpleName(), message.cause().getMessage());
                 log.error(errMessage);
+                promise.fail(ErrorEnum.ERROR_NO_SUCH_MESSAGE.method());
             }
         };
     }

--- a/zimbra/src/main/java/fr/openent/zimbra/model/task/RecallTask.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/task/RecallTask.java
@@ -10,12 +10,14 @@ import java.util.UUID;
 
 public class RecallTask extends Task<RecallTask> {
     private final RecallMail recallMessage;
+    private String receiverEmail;
     private final UUID receiverId;
     private final int retry;
 
-    public RecallTask(long id, TaskStatus status, Action<RecallTask> action, RecallMail recallMessage, UUID receiverId, int retry) {
+    public RecallTask(long id, TaskStatus status, Action<RecallTask> action, RecallMail recallMessage, UUID receiverId, String receiverEmail, int retry) {
         super(id, status, action);
         this.recallMessage = recallMessage;
+        this.receiverEmail = receiverEmail;
         this.receiverId = receiverId;
         this.retry = retry;
     }
@@ -29,6 +31,7 @@ public class RecallTask extends Task<RecallTask> {
             this.id = dbData.getInteger(Field.ID, -1);
             this.receiverId = UUID.fromString(dbData.getString(Field.RECEIVER_ID));
             this.retry = dbData.getInteger(Field.RETRY);
+            this.receiverEmail = dbData.getString(Field.RECIPIENT_ADDRESS);
             this.recallMessage = recallMessage;
         } catch (Exception e) {
             throw new Exception(String.format("[Zimbra@%s::RecallTask] Bad field format", this.getClass().getSimpleName()));
@@ -51,4 +54,7 @@ public class RecallTask extends Task<RecallTask> {
         return retry;
     }
 
+    public String getReceiverEmail() {
+        return receiverEmail;
+    }
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -1168,10 +1168,10 @@ public class MessageService {
         });
     }
 
-    public Future<List<String>> retrieveMailFromZimbra(JsonObject returnedMail, JsonObject to_user_infos) {
+    public Future<List<String>> retrieveMailFromZimbra(JsonObject returnedMail, JsonObject toUserInfos) {
         Promise<List<String>> promise = Promise.promise();
 
-        retrieveMailFromZimbra(returnedMail, to_user_infos, res -> {
+        retrieveMailFromZimbra(returnedMail, toUserInfos, res -> {
             if (res.isRight()) {
                 promise.complete(res.right().getValue());
             } else {

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -19,6 +19,7 @@ package fr.openent.zimbra.service.impl;
 
 import fr.openent.zimbra.Zimbra;
 import fr.openent.zimbra.core.constants.Field;
+import fr.openent.zimbra.core.enums.ErrorEnum;
 import fr.openent.zimbra.helper.*;
 import fr.openent.zimbra.model.MailAddress;
 import fr.openent.zimbra.model.ZimbraUser;
@@ -1165,6 +1166,24 @@ public class MessageService {
                 result.handle(new Either.Right<>(new JsonObject()));
             }
         });
+    }
+
+    public Future<List<String>> retrieveMailFromZimbra(JsonObject returnedMail, JsonObject to_user_infos) {
+        Promise<List<String>> promise = Promise.promise();
+
+        retrieveMailFromZimbra(returnedMail, to_user_infos, res -> {
+            if (res.isRight()) {
+                promise.complete(res.right().getValue());
+            } else {
+                String errMessage = String.format("[Zimbra@%s::retrieveMailFromZimbra]:  " +
+                                "error while retrieving mail from zimbra : %s",
+                        this.getClass().getSimpleName(), res.left().getValue());
+                log.error(errMessage);
+                promise.fail(ErrorEnum.ERROR_RETRIEVING_MAIL.method());
+            }
+        });
+
+        return promise.future();
     }
 
     /**

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/NotificationService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/NotificationService.java
@@ -22,7 +22,6 @@ import fr.openent.zimbra.model.MailAddress;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -121,6 +120,7 @@ public class NotificationService {
                 .put("user", user.getLastName() + " " + user.getFirstName())
                 .put("subject", subject)
                 .put("adminUri", "/admin/" + idStructure +"/management/zimbra")
+                .put("resourceUri", "/admin/" + idStructure +"/management/zimbra")
                 .put("pushNotif", new JsonObject().put("title", "push.notif.zimbra.delete.request").put("body", ""));
 
         timelineHelper.notifyTimeline(request, "messagerie.return-message",

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/helpers/CalendarEventBusHelper.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/helpers/CalendarEventBusHelper.java
@@ -16,7 +16,7 @@ public class CalendarEventBusHelper {
                 .put(Field.ERROR, error);
     }
 
-    public static JsonObject createSuccedAnswerAndSetAction(String action, JsonObject result) {
+    public static JsonObject createSucceedAnswerAndSetAction(String action, JsonObject result) {
         return generateSuccessNotification(result)
                 .put(Field.ACTION, action);
     }

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/DbRecallMail.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/DbRecallMail.java
@@ -24,7 +24,7 @@ public abstract class DbRecallMail {
      */
     public abstract Future<RecallMail> createRecallMail(RecallMail recallMail, UserInfos user);
     public abstract Future<List<RecallMail>> getRecallMailByStruct(String structureId);
-    public abstract Future<JsonObject> acceptRecall(int recallId);
+    public abstract Future<Void> acceptRecall(int recallId);
 
     public abstract Future<JsonArray> checkRecalledInMailList(String userId, JsonArray messageList);
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/DbRecallMail.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/DbRecallMail.java
@@ -1,8 +1,13 @@
 package fr.openent.zimbra.tasks.service;
 
+import fr.openent.zimbra.core.enums.ActionStatus;
 import fr.openent.zimbra.model.message.RecallMail;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.entcore.common.user.UserInfos;
+
+import java.util.List;
 
 public abstract class DbRecallMail {
     private final String schema;
@@ -18,4 +23,8 @@ public abstract class DbRecallMail {
      * @return              Recall mail
      */
     public abstract Future<RecallMail> createRecallMail(RecallMail recallMail, UserInfos user);
+    public abstract Future<List<RecallMail>> getRecallMailByStruct(String structureId);
+    public abstract Future<JsonObject> acceptRecall(int recallId);
+
+    public abstract Future<JsonArray> checkRecalledInMailList(String userId, JsonArray messageList);
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/QueueService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/QueueService.java
@@ -215,7 +215,8 @@ public abstract class QueueService<T extends Task<T>> {
         dbTaskService.retrieveTasksDataFromDB(TaskStatus.PENDING)
                 .onSuccess(taskData -> {
                     try {
-                        promise.complete(createTasksAndActionFromData(taskData));
+                        List<T> tasks = createTasksAndActionFromData(taskData);
+                        promise.complete(tasks);
                     } catch (Exception e) {
                         String errMessage = String.format("[Zimbra@%s::getPendingTasks]: fail fetching model from data: %s",
                                 this.getClass().getSimpleName(), e.getMessage());
@@ -308,7 +309,7 @@ public abstract class QueueService<T extends Task<T>> {
             Action<T> action;
             action = getActionById(taskData.getInteger(Field.ACTION_ID, null));
             if (action == null) {
-                action = new Action<>(taskData);
+                action = new Action<>(new JsonObject(taskData.getString(Field.ACTION)));
                 this.actionList.add(action);
             }
             T newTask = createTaskFromData(taskData, action);

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/RecallMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/RecallMailService.java
@@ -3,6 +3,7 @@ package fr.openent.zimbra.tasks.service;
 
 import fr.openent.zimbra.model.message.RecallMail;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
 import org.entcore.common.user.UserInfos;
 
 import java.util.List;
@@ -15,6 +16,14 @@ public interface RecallMailService {
      * @return
      */
     public Future<List<RecallMail>> getRecallMails ();
+
+    public Future<Void> acceptRecall(int recallId);
+
+    /**
+     * Get Recall mails for a specific structure
+     * @return
+     */
+    public Future<List<RecallMail>> getRecallMailsForOneStructure (String structureId);
 
     /**
      *
@@ -42,8 +51,10 @@ public interface RecallMailService {
 
     /**
      *
-     * @param recallMailId
+     * @param recallMail
      * @return
      */
-    public Future<Void> deleteMessage (String recallMailId);
+    public Future<Void> deleteMessage (RecallMail recallMail, UserInfos user, String receiverEmail, String senderEmail);
+
+    public Future<JsonArray> renderRecallMails(UserInfos user, JsonArray messageList);
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallMailServiceImpl.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallMailServiceImpl.java
@@ -245,20 +245,11 @@ public class RecallMailServiceImpl implements RecallMailService {
         JsonObject userRecallInfos = new JsonObject().put(Field.ID, user.getUserId()).put(Field.MAIL, receiverEmail);
 
         messageService.retrieveMailFromZimbra(returnedMailInfos, userRecallInfos)
-                .onSuccess(mail -> {
-                    messageService.deleteMessages(mail, user, false)
-                            .onSuccess(promise::complete)
-                            .onFailure(err -> {
-                                String errMessage = String.format("[Zimbra@%s::deleteMessage]:  " +
-                                                "error while deleting mail: %s",
-                                        this.getClass().getSimpleName(), err.getMessage());
-                                log.error(errMessage);
-                                promise.fail(ErrorEnum.ERROR_DELETING_MAIL.method());
-                            });
-                })
+                .compose(mail -> messageService.deleteMessages(mail, user, false))
+                .onSuccess(promise::complete)
                 .onFailure(err -> {
                     String errMessage = String.format("[Zimbra@%s::deleteMessage]:  " +
-                                    "error while retrieving mail id : %s",
+                                    "error while deleting mail: %s",
                             this.getClass().getSimpleName(), err.getMessage());
                     log.error(errMessage);
                     promise.fail(ErrorEnum.ERROR_DELETING_MAIL.method());

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallMailServiceImpl.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallMailServiceImpl.java
@@ -1,29 +1,36 @@
 package fr.openent.zimbra.tasks.service.impl;
 
+import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.core.enums.ActionType;
 import fr.openent.zimbra.core.enums.ErrorEnum;
 import fr.openent.zimbra.core.enums.TaskStatus;
-import fr.openent.zimbra.helper.ConfigManager;
+import fr.openent.zimbra.helper.IModelHelper;
 import fr.openent.zimbra.helper.MessageHelper;
+import fr.openent.zimbra.model.action.Action;
 import fr.openent.zimbra.model.message.Message;
 import fr.openent.zimbra.model.message.RecallMail;
 import fr.openent.zimbra.model.soap.SoapMessageHelper;
 import fr.openent.zimbra.model.task.RecallTask;
+import fr.openent.zimbra.service.impl.MessageService;
 import fr.openent.zimbra.service.impl.NotificationService;
 import fr.openent.zimbra.service.impl.RecipientService;
 import fr.openent.zimbra.tasks.service.DbRecallMail;
 import fr.openent.zimbra.tasks.service.RecallMailService;
 import fr.openent.zimbra.service.StructureService;
-import fr.openent.zimbra.service.data.Neo4jZimbraService;
+import fr.openent.zimbra.utils.DateUtils;
+import fr.wseduc.webutils.Either;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.NotImplementedException;
 import org.entcore.common.user.UserInfos;
 
-import java.util.List;
-import java.util.UUID;
+import java.text.SimpleDateFormat;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static fr.openent.zimbra.model.constant.ZimbraConstants.ADDR_TYPE_FROM;
@@ -34,22 +41,45 @@ public class RecallMailServiceImpl implements RecallMailService {
     private final StructureService structureService;
     private final DbRecallMail dbMailService;
     private final RecipientService recipientService;
+    private final MessageService messageService;
 
     private static final int BATCH_SIZE = 100;
     private static final Logger log = LoggerFactory.getLogger(RecallMailServiceImpl.class);
 
-    public RecallMailServiceImpl(DbRecallMail dbMailService, Neo4jZimbraService neo4jZimbraService, RecallQueueServiceImpl recallQueueService,
+    public RecallMailServiceImpl(DbRecallMail dbMailService, MessageService messageService, RecallQueueServiceImpl recallQueueService,
                                  NotificationService notificationService, StructureService structureService, RecipientService recipientService) {
         this.dbMailService = dbMailService;
         this.recallQueueService = recallQueueService;
         this.notificationService = notificationService;
         this.structureService = structureService;
         this.recipientService = recipientService;
+        this.messageService = messageService;
     }
 
     public Future<List<RecallMail>> getRecallMails () {
         throw new NotImplementedException();
     }
+
+    @Override
+    public Future<Void> acceptRecall(int recallId) {
+        Promise<Void> promise = Promise.promise();
+
+        dbMailService.acceptRecall(recallId)
+                .onSuccess(v -> promise.complete())
+                .onFailure(err -> {
+                    String errMessage = String.format("[Zimbra@%s::acceptRecall]:  " +
+                                    "error while accepting recall: %s",
+                            this.getClass().getSimpleName(), err.getMessage());
+                    log.error(errMessage);
+                    promise.fail(ErrorEnum.FAIL_ACCEPT_RECALL.method());
+                });
+
+        return promise.future();
+    }
+
+    public Future<List<RecallMail>> getRecallMailsForOneStructure (String structureId) {
+        return dbMailService.getRecallMailByStruct(structureId);
+   }
 
     private Future<Message> fetchUserIdForRecalledMessage(Message message) {
         Promise<Message> promise = Promise.promise();
@@ -119,7 +149,12 @@ public class RecallMailServiceImpl implements RecallMailService {
                 .stream()
                 .filter(addr -> !addr.getAddrType().equals(ADDR_TYPE_FROM) && mail.getMessage().getUserMapping().containsKey(addr.getAddress()))
                 .map(addr -> new RecallTask(
-                        -1, TaskStatus.PENDING, mail.getAction(), mail, UUID.fromString(mail.getMessage().getUserMapping().get(addr.getAddress()).getUserId()), 0)
+                        -1,
+                        TaskStatus.PENDING,
+                        mail.getAction(),
+                        mail, UUID.fromString(mail.getMessage().getUserMapping().get(addr.getAddress()).getUserId()),
+                        addr.getAddress(),
+                        0)
                 )
                 .collect(Collectors.toList()
         );
@@ -200,7 +235,83 @@ public class RecallMailServiceImpl implements RecallMailService {
         throw new NotImplementedException();
     }
 
-    public Future<Void> deleteMessage (String recallMailId) {
-        return null;
+    public Future<Void> deleteMessage (RecallMail recallMail, UserInfos user, String receiverEmail, String senderEmail) {
+        Promise<Void> promise = Promise.promise();
+
+        messageService.retrieveMailFromZimbra(
+                new JsonObject()
+                        .put(Field.USER_MAIL, senderEmail)
+                        .put(Field.MID, recallMail.getMessage().getMailId().substring(1, recallMail.getMessage().getMailId().length() - 1)),
+                new JsonObject().put(Field.ID, user.getUserId()).put(Field.MAIL, receiverEmail),
+                mailId -> {
+                    if (mailId.isRight()) {
+                        messageService.deleteMessages(mailId.right().getValue(), user, false)
+                                .onSuccess(promise::complete)
+                                .onFailure(err -> {
+                                    String errMessage = String.format("[Zimbra@%s::deleteMessage]:  " +
+                                                    "error while deleting mail: %s",
+                                            this.getClass().getSimpleName(), err.getMessage());
+                                    log.error(errMessage);
+                                    promise.fail(ErrorEnum.ERROR_DELETING_MAIL.method());
+                                });
+                    } else {
+                        String errMessage = String.format("[Zimbra@%s::deleteMessage]:  " +
+                                        "error while retrieving mail id : %s",
+                                this.getClass().getSimpleName(), mailId.left().getValue());
+                        log.error(errMessage);
+                        promise.fail(ErrorEnum.ERROR_DELETING_MAIL.method());
+                    }
+                }
+
+        );
+
+        return promise.future();
     }
+
+    private String determineStatus(JsonObject mailData) {
+        try {
+            if (!mailData.getBoolean(Field.APPROVED)) {
+                return Field.CAPITAL_WAITING;
+            } else if (mailData.getInteger(TaskStatus.PENDING.method()) > 0) {
+                return Field.CAPITAL_PROGRESS;
+            } else {
+                return Field.CAPITAL_REMOVED;
+            }
+        } catch (Exception e) {
+            String errMessage = String.format("[Zimbra@%s::determineStatus]:  " +
+                            "error while retrieving status from recall data : %s",
+                    this.getClass().getSimpleName(), e.getMessage());
+            log.error(errMessage);
+            return "";
+        }
+    }
+
+    @Override
+    public Future<JsonArray> renderRecallMails(UserInfos user, JsonArray messageList) {
+        Promise<JsonArray> promise = Promise.promise();
+        dbMailService.checkRecalledInMailList(user.getUserId(), messageList)
+                .onSuccess(correspondingRecall -> {
+                    correspondingRecall.stream()
+                            .filter(JsonObject.class::isInstance)
+                            .map(mail -> (JsonObject) mail)
+                            .forEach(recallMessage -> {
+                                String recallId = recallMessage.getString(Field.LOCAL_MAIL_ID);
+                                String status = determineStatus(recallMessage);
+                                messageList
+                                        .stream()
+                                        .filter(message -> message instanceof JsonObject && Objects.equals(((JsonObject) message).getString(Field.ID), recallId))
+                                        .map(JsonObject.class::cast)
+                                        .forEach(message -> message.put(Field.RETURNED, status));
+                            });
+                    promise.complete(messageList);
+                })
+                .onFailure(err -> {
+                    String errMessage = String.format("[Zimbra@%s::determineStatus]:  " +
+                                    "error while retrieving status from recall data : %s",
+                            this.getClass().getSimpleName(), err.getMessage());
+                    log.error(errMessage);
+                    promise.fail(ErrorEnum.ERROR_RECALL_RETRIEVE.method());
+                });
+        return promise.future();
+       }
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallQueueServiceImpl.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallQueueServiceImpl.java
@@ -32,14 +32,16 @@ public class RecallQueueServiceImpl extends QueueService<RecallTask> {
                 action,
                 null,
                 UUID.fromString(data.getString(Field.RECEIVER_ID)),
+                data.getString(Field.RECIPIENT_ADDRESS),
                 data.getInteger(Field.RETRY)));
     }
 
     protected RecallTask createTaskFromData(JsonObject taskData, Action<RecallTask> action) throws Exception {
-        Message message = Message.fromZimbra(new JsonObject().put(Field.MESSAGE_ID, taskData.getString(Field.MESSAGE_ID)));
+        JsonObject recallData = new JsonObject(taskData.getString(Field.RECALL_MAIL));
+        Message message = Message.fromZimbra(new JsonObject().put(Field.MID, recallData.getString(Field.MESSAGE_ID)));
         return new RecallTask(      taskData,
                                     action,
-                                    new RecallMail(taskData.getInteger(Field.RECALL_MAIL_ID), message)
+                                    new RecallMail(taskData.getInteger(Field.RECALL_MAIL_ID), message,recallData.getString(Field.USER_MAIL))
         );
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/data/SqlICalTaskService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/data/SqlICalTaskService.java
@@ -35,7 +35,7 @@ public class SqlICalTaskService extends DbTaskService<ICalTask> {
     @Override
     protected Future<JsonArray> retrieveTasksDataFromDB(TaskStatus status) {
         Promise<JsonArray> promise = Promise.promise();
-        String query = "SELECT ical_tasks.*, actions.user_id, actions.created_at, actions.type, actions.approved "
+        String query = "SELECT ical_tasks.*, to_json(actions.*) as action "
         + "FROM " + this.taskTable + " as ical_tasks "
         + "join " + this.actionTable + " as actions on actions.id = ical_tasks.action_id "
         + "WHERE " + "ical_tasks.status = ? "

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/data/SqlRecallMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/data/SqlRecallMailService.java
@@ -100,8 +100,6 @@ public class SqlRecallMailService extends DbRecallMail {
         return promise.future();
     }
 
-//    private Future<>
-
     private Future<JsonArray> retrieveRecallByStruct(String structureId) {
         Promise<JsonArray> promise = Promise.promise();
 

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/data/SqlRecallMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/data/SqlRecallMailService.java
@@ -1,10 +1,18 @@
 package fr.openent.zimbra.tasks.service.impl.data;
 
 import fr.openent.zimbra.core.constants.Field;
+import fr.openent.zimbra.core.enums.ActionStatus;
 import fr.openent.zimbra.core.enums.ErrorEnum;
+import fr.openent.zimbra.core.enums.TaskStatus;
+import fr.openent.zimbra.helper.IModelHelper;
 import fr.openent.zimbra.helper.PromiseHelper;
+import fr.openent.zimbra.model.action.Action;
+import fr.openent.zimbra.model.message.Message;
 import fr.openent.zimbra.model.message.RecallMail;
+import fr.openent.zimbra.model.message.ZimbraEmail;
+import fr.openent.zimbra.model.task.RecallTask;
 import fr.openent.zimbra.tasks.service.DbRecallMail;
+import fr.openent.zimbra.utils.DateUtils;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
@@ -15,31 +23,44 @@ import org.entcore.common.sql.Sql;
 import org.entcore.common.sql.SqlResult;
 import org.entcore.common.user.UserInfos;
 
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class SqlRecallMailService extends DbRecallMail {
     private final String recallMailTable;
+    private final String actionTable;
+    private final String recallTaskTable;
     private static final Logger log = LoggerFactory.getLogger(SqlRecallMailService.class);
+    public static final String ADDR_TYPE_FROM = "f";
 
     public SqlRecallMailService(String schema) {
         super(schema);
         recallMailTable = schema + "." + "recall_mails";
+        this.actionTable = schema + "." + "actions";
+        this.recallTaskTable = schema + "." + "recall_recipient_tasks";
     }
 
-    private Future<JsonObject> insertRecallMailDb(RecallMail recallMail, UserInfos user) {
+    protected Future<JsonObject> insertRecallMailDb(RecallMail recallMail, UserInfos user) {
         Promise<JsonObject> promise = Promise.promise();
 
         String query = "INSERT INTO " +
                 this.recallMailTable +
-                " (" + Field.ACTION_ID + "," + Field.USER_NAME + "," + Field.MESSAGE_ID + "," + Field.STRUCTURES + "," + Field.OBJECT + "," + Field.COMMENT + "," + Field.MAIL_DATE +  ") " +
-                "VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING " + Field.ID + ";";
+                " (" + Field.ACTION_ID + "," + Field.USER_NAME + "," + Field.USER_MAIL +"," + Field.LOCAL_MAIL_ID + "," + Field.MESSAGE_ID + "," + Field.STRUCTURES + "," + Field.OBJECT + "," + Field.COMMENT + "," + Field.MAIL_DATE +  ") " +
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING " + Field.ID + ";";
+
+        String senderAddress = recallMail.getMessage().getEmailAddresses().stream().filter(addr -> addr.getAddrType().equals(ADDR_TYPE_FROM)).findFirst().map(ZimbraEmail::getAddress).orElse("");
 
         JsonArray values = new JsonArray();
         values
                 .add(recallMail.getAction().getId())
                 .add(user.getUsername())
+                .add(senderAddress)
+                .add(recallMail.getMessage().getId())
                 .add(recallMail.getMessage().getMailId())
-                .add(new JsonArray(user.getStructures()))
+                .add(new JsonArray(user.getStructures().stream().map(id -> new JsonObject().put(Field.ID, id)).collect(Collectors.toList())))
                 .add(recallMail.getMessage().getSubject())
                 .add(recallMail.getComment())
                 .add(new Date(recallMail.getMessage().getDate()).toString());
@@ -48,6 +69,8 @@ public class SqlRecallMailService extends DbRecallMail {
 
         return promise.future();
     }
+
+
 
     @Override
     public Future<RecallMail> createRecallMail(RecallMail recallMail, UserInfos user) {
@@ -76,4 +99,120 @@ public class SqlRecallMailService extends DbRecallMail {
 
         return promise.future();
     }
+
+//    private Future<>
+
+    private Future<JsonArray> retrieveRecallByStruct(String structureId) {
+        Promise<JsonArray> promise = Promise.promise();
+
+        String query = "SELECT rm.*, json_agg(rct.*) as tasks, to_json(act.*) as action FROM " +
+                this.recallMailTable + " AS rm " +
+                "INNER JOIN " + this.recallTaskTable + " AS rct ON rct.action_id = rm.action_id " +
+                "INNER JOIN " + this.actionTable + " AS act ON act.id = rm.action_id " +
+                "WHERE ? IN (SELECT (json_array_elements(rm.structures)->>'id') " +
+                "FROM " + this.recallMailTable + ") group by rm.id, act.id;";
+
+        JsonArray values = new JsonArray().add(structureId);
+
+        Sql.getInstance().prepared(query, values, SqlResult.validResultHandler(PromiseHelper.handlerJsonArray(promise)));
+
+        return promise.future();
+    }
+
+    @Override
+    public Future<List<RecallMail>> getRecallMailByStruct(String structureId) {
+        Promise<List<RecallMail>> promise = Promise.promise();
+
+        retrieveRecallByStruct(structureId)
+                .onSuccess(mailList -> {
+                    try {
+                        promise.complete(IModelHelper.toList(mailList, mailData -> {
+                                long date;
+                                Action<RecallTask> action = null;
+                                try {
+                                    date = new SimpleDateFormat(DateUtils.DATE_FORMAT_SQL).parse(mailData.getString(Field.MAIL_DATE)).getTime();
+                                    action = new Action<>(new JsonObject(mailData.getString(Field.ACTION)));
+                                    action.addTasks(IModelHelper.toList(new JsonArray(mailData.getString(Field.TASKS)), taskData ->
+                                            new RecallTask(taskData.getInteger(Field.ID),
+                                                    TaskStatus.fromString(taskData.getString(Field.STATUS)),
+                                                    null,
+                                                    null,
+                                                    null,
+                                                    taskData.getString(Field.RECIPIENT_ADDRESS),
+                                                    taskData.getInteger(Field.RETRY))
+                                            )
+                                    );
+                                } catch (Exception e) {
+                                    date = -1;
+                                }
+                                return new RecallMail(
+                                        mailData.getInteger(Field.ID),
+                                        new Message(
+                                                null,
+                                                mailData.getString(Field.OBJECT),
+                                                mailData.getString(Field.MESSAGE_ID),
+                                                date
+                                                ),
+                                        action,
+                                        mailData.getString(Field.COMMENT)
+                                        );
+                        }));
+                    } catch (Exception e) {
+                        promise.complete(new ArrayList<>());
+                        String errMessage = String.format("[Zimbra@%s::getRecallMailByStruct]:  " +
+                                        "fail to fetch recall mail: %s",
+                                this.getClass().getSimpleName(), e.getMessage());
+                        log.error(errMessage);
+                        promise.fail(ErrorEnum.ERROR_FETCHING_MODEL.method());
+                    }
+                })
+                .onFailure(err -> {
+                    String errMessage = String.format("[Zimbra@%s::getRecallMailByStruct]:  " +
+                                    "fail to retrieve recall mails data: %s",
+                            this.getClass().getSimpleName(), err.getMessage());
+                    log.error(errMessage);
+                    promise.fail(ErrorEnum.ERROR_RETRIEVING_MAIL.method());
+                });
+        return promise.future();
+    }
+
+    @Override
+    public Future<JsonObject> acceptRecall(int recallId) {
+        Promise<JsonObject> promise = Promise.promise();
+
+        String query = "UPDATE " + this.actionTable +
+                " SET approved = true " +
+                "WHERE zimbra.actions.id = (select action_id from " + this.recallMailTable + " where id = ?);";
+
+        JsonArray values = new JsonArray().add(recallId);
+
+        Sql.getInstance().prepared(query, values, SqlResult.validUniqueResultHandler(PromiseHelper.handlerJsonObject(promise)));
+
+        return promise.future();
+    }
+
+    @Override
+    public Future<JsonArray> checkRecalledInMailList(String userId, JsonArray messageList) {
+        Promise<JsonArray> promise = Promise.promise();
+
+        List<String> messageIdList = messageList  .stream()
+                .filter(JsonObject.class::isInstance)
+                .map(mail -> (JsonObject) mail)
+                .map(mail -> mail.getString(Field.ID)).collect(Collectors.toList());
+
+        String query = "SELECT rm.*, act.approved," +
+                "count(rt.status) filter ( WHERE status = '" + TaskStatus.FINISHED.method() + "') AS finished," +
+                "count(rt.status) filter ( WHERE status = '" + TaskStatus.PENDING.method() + "') AS pending," +
+                "count(rt) AS total FROM " + this.recallMailTable + " AS rm " +
+                "INNER JOIN " + this.actionTable + " AS act on act.id = rm.action_id " +
+                "INNER JOIN " + this.recallTaskTable + " AS rt on rt.action_id = act.id " +
+                "WHERE rm.local_mail_id in " + Sql.listPrepared(messageIdList) + " GROUP BY rm.id, act.approved;";
+
+        JsonArray values = new JsonArray(messageIdList);
+
+        Sql.getInstance().prepared(query, values, SqlResult.validResultHandler(PromiseHelper.handlerJsonArray(promise)));
+
+        return promise.future();
+    }
+
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/worker/ICalRequestWorker.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/worker/ICalRequestWorker.java
@@ -10,7 +10,6 @@ import fr.openent.zimbra.helper.StringHelper;
 import fr.openent.zimbra.model.task.ICalTask;
 import fr.openent.zimbra.service.CalendarService;
 import fr.openent.zimbra.tasks.helpers.CalendarEventBusHelper;
-import fr.openent.zimbra.tasks.service.QueueService;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -30,7 +29,6 @@ public class ICalRequestWorker extends QueueWorker<ICalTask> implements Handler<
     public static final String ZIMBRA_ACTION_ICS = "zimbra-platform-ics";
 
     private CalendarService calendarService;
-    private QueueService<ICalTask> queueService;
 
     @Override
     public void start() throws Exception {
@@ -39,7 +37,7 @@ public class ICalRequestWorker extends QueueWorker<ICalTask> implements Handler<
         this.setMaxQueueSize(configManager.getZimbraICalWorkerMaxQueue());
         this.eb.localConsumer(this.getClass().getName(), this);
         this.calendarService = ServiceManager.getServiceManager().getCalendarService();
-        this.queueService = ServiceManager.getServiceManager().getICalQueueService();
+        this.queueService = serviceManager.getICalQueueService();
     }
 
     @Override

--- a/zimbra/src/main/java/fr/openent/zimbra/worker/ICalRequestWorker.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/worker/ICalRequestWorker.java
@@ -71,7 +71,7 @@ public class ICalRequestWorker extends QueueWorker<ICalTask> implements Handler<
                                         this.getClass().getSimpleName(), err.getMessage());
                                 log.error(errMessage);
                             });
-                    notifyCalendarModule(CalendarEventBusHelper.createSuccedAnswerAndSetAction(ZIMBRA_ACTION_ICS, icalDataAsJson(ical, task)))
+                    notifyCalendarModule(CalendarEventBusHelper.createSucceedAnswerAndSetAction(ZIMBRA_ACTION_ICS, icalDataAsJson(ical, task)))
                             .onFailure(err -> {
                                 String errMessage = String.format("[Zimbra@%s::retrieveIcalAndNotifyCalendar]: error notify calendar: %s",
                                         this.getClass().getSimpleName(), err.getMessage());

--- a/zimbra/src/main/java/fr/openent/zimbra/worker/QueueWorker.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/worker/QueueWorker.java
@@ -16,13 +16,14 @@ import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 import java.util.*;
 
 abstract class QueueWorker<T extends Task<T>> extends AbstractVerticle implements Handler<Message<JsonObject>> {
     protected final ConfigManager configManager = new ConfigManager(Vertx.currentContext().config());
     protected final ServiceManager serviceManager = ServiceManager.getServiceManager();
-    protected Logger log;
+    protected static Logger log = LoggerFactory.getLogger(QueueWorker.class);;
     protected boolean running = false;
     protected QueueWorkerStatus workerStatus = QueueWorkerStatus.NOT_STARTED;
 
@@ -102,7 +103,6 @@ abstract class QueueWorker<T extends Task<T>> extends AbstractVerticle implement
     }
     public void addTasks(List<T> tasks) {
         if (tasks == null || tasks.isEmpty()) {
-            log.error("[ZimbraConnector@ICalRequestWorker:addTasks] taskIds cannot be null or empty");
             return;
         }
         if (this.queue.size() + tasks.size() > this.maxQueueSize) {

--- a/zimbra/src/main/java/fr/openent/zimbra/worker/RecallMailWorker.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/worker/RecallMailWorker.java
@@ -1,15 +1,19 @@
 package fr.openent.zimbra.worker;
 
+import fr.openent.zimbra.core.enums.ErrorEnum;
+import fr.openent.zimbra.core.enums.TaskStatus;
 import fr.openent.zimbra.model.task.RecallTask;
 import fr.openent.zimbra.tasks.service.RecallMailService;
 import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.user.UserUtils;
 
 public class RecallMailWorker extends QueueWorker<RecallTask> {
     public final RecallMailService recallMailService = serviceManager.getRecallMailService();
-    public static final String RECALL_MAIL_HANDLER_ADDRESS = "zimbra.handler";
+    public static final String RECALL_MAIL_HANDLER_ADDRESS = "zimbra.recall.handler";
 
     public RecallMailWorker() {
         super.log = LoggerFactory.getLogger(RecallMailWorker.class);
+        this.queueService = serviceManager.getRecallQueueService();
     }
 
     @Override
@@ -20,6 +24,23 @@ public class RecallMailWorker extends QueueWorker<RecallTask> {
     }
 
     public void execute(RecallTask task) {
-        recallMailService.deleteMessage(task.getRecallMessage().getMessage().getMailId());
+        UserUtils.getUserInfos(eb, task.getReceiverId().toString(), user -> {
+
+            recallMailService.deleteMessage(task.getRecallMessage(), user, task.getReceiverEmail(), task.getRecallMessage().getSenderEmail())
+                    .compose(isDeleted -> queueService.editTaskStatus(task, TaskStatus.FINISHED))
+                    .onFailure(err -> {
+                        queueService.logFailureOnTask(task, ErrorEnum.ERROR_UPDATING_TASK.method())
+                                .onFailure(error -> {
+                                    String errMessage = String.format("[Zimbra@%s::execute]:  " +
+                                                    "an error has occurred while updating task status: %s",
+                                            this.getClass().getSimpleName(), error.getMessage());
+                                    log.error(errMessage);
+                                });
+                        String errMessage = String.format("[Zimbra@%s::execute]:  " +
+                                        "an error has occurred while executing recall task: %s",
+                                this.getClass().getSimpleName(), err.getMessage());
+                        log.error(errMessage);
+                    });
+        });
     }
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/worker/RecallMailWorker.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/worker/RecallMailWorker.java
@@ -25,22 +25,29 @@ public class RecallMailWorker extends QueueWorker<RecallTask> {
 
     public void execute(RecallTask task) {
         UserUtils.getUserInfos(eb, task.getReceiverId().toString(), user -> {
+            if (user != null) {
+                recallMailService.deleteMessage(task.getRecallMessage(), user, task.getReceiverEmail(), task.getRecallMessage().getSenderEmail())
+                        .compose(isDeleted -> queueService.editTaskStatus(task, TaskStatus.FINISHED))
+                        .onFailure(err -> {
+                            queueService.logFailureOnTask(task, ErrorEnum.ERROR_UPDATING_TASK.method())
+                                    .onFailure(error -> {
+                                        String errMessage = String.format("[Zimbra@%s::execute]:  " +
+                                                        "an error has occurred while updating task status: %s",
+                                                this.getClass().getSimpleName(), error.getMessage());
+                                        log.error(errMessage);
+                                    });
+                            String errMessage = String.format("[Zimbra@%s::execute]:  " +
+                                            "an error has occurred while executing recall task: %s",
+                                    this.getClass().getSimpleName(), err.getMessage());
+                            log.error(errMessage);
+                        });
+            } else {
+                String errMessage = String.format("[Zimbra@%s::execute]:  " +
+                                "an error has occurred while fetching user",
+                        this.getClass().getSimpleName());
+                log.error(errMessage);
+            }
 
-            recallMailService.deleteMessage(task.getRecallMessage(), user, task.getReceiverEmail(), task.getRecallMessage().getSenderEmail())
-                    .compose(isDeleted -> queueService.editTaskStatus(task, TaskStatus.FINISHED))
-                    .onFailure(err -> {
-                        queueService.logFailureOnTask(task, ErrorEnum.ERROR_UPDATING_TASK.method())
-                                .onFailure(error -> {
-                                    String errMessage = String.format("[Zimbra@%s::execute]:  " +
-                                                    "an error has occurred while updating task status: %s",
-                                            this.getClass().getSimpleName(), error.getMessage());
-                                    log.error(errMessage);
-                                });
-                        String errMessage = String.format("[Zimbra@%s::execute]:  " +
-                                        "an error has occurred while executing recall task: %s",
-                                this.getClass().getSimpleName(), err.getMessage());
-                        log.error(errMessage);
-                    });
         });
     }
 }

--- a/zimbra/src/main/resources/jsonschema/recallMail.json
+++ b/zimbra/src/main/resources/jsonschema/recallMail.json
@@ -11,6 +11,6 @@
     }
   },
   "required": [
-    "id", "comment"
+    "id"
   ]
 }

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -836,7 +836,7 @@ export let zimbraController = ng.controller("ZimbraController", [
             $scope.lightbox.show = false;
             template.close("lightbox");
             var data: any = {id: id, comment: comment};
-            let response = await http.put("/zimbra/return", data);
+            let response = await http.put("/zimbra/recall", data);
             if(response.status == 200) {
                 $scope.refresh();
                 $scope.$apply();

--- a/zimbra/src/main/resources/sql/011-zimbra-tasks-logs.sql
+++ b/zimbra/src/main/resources/sql/011-zimbra-tasks-logs.sql
@@ -1,0 +1,21 @@
+DROP TABLE zimbra.task_logs;
+CREATE TABLE zimbra.recall_task_logs
+(
+    id      bigserial NOT NULL,
+    recall_task_id bigint,
+    logs    varchar,
+    CONSTRAINT recall_task_logs_pkey PRIMARY KEY (id),
+    CONSTRAINT recall_task_id_fkey FOREIGN KEY (recall_task_id) REFERENCES zimbra.tasks(id)
+);
+CREATE TABLE zimbra.ical_task_logs
+(
+    id      bigserial NOT NULL,
+    ical_task_id bigint,
+    logs    varchar,
+    CONSTRAINT ical_task_logs_pkey PRIMARY KEY (id),
+    CONSTRAINT ical_task_id_fkey FOREIGN KEY (ical_task_id) REFERENCES zimbra.tasks(id)
+);
+
+ALTER TABLE zimbra.recall_mails ADD completed boolean, ADD local_mail_id varchar;
+ALTER TABLE zimbra.recall_mails ADD CONSTRAINT unique_local_id UNIQUE(local_mail_id);
+ALTER TABLE zimbra.recall_recipient_tasks add recipient_address varchar;


### PR DESCRIPTION
## Describe your changes
Added all the recall task logic to the queue and worker services, it is the finla step of recall mail rework.
New routes were added, replacing ancient ones with new name and more data.

API DOC: https://confluence.support-ent.fr/display/ZIM/Messages
## Checklist tests
- [x] Create a recall mail
- [x] Wait until the cron passes and treat tasks
## Issue ticket number and link
[ MZI-198 ]
https://jira.support-ent.fr/browse/MZI-198
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)