### PR TITLE
fix(recall): #MZI-224 fix recall for groups

### DIFF
--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -852,7 +852,7 @@ public class ZimbraController extends BaseController {
                     return;
                 }
 
-                messageService.deleteMessages(messageIds, user, true)
+                messageService.deleteMessages(messageIds, user.getUserId(), true)
                         .onSuccess(res -> Renders.renderJson(request, new JsonObject(),200))
                         .onFailure(err -> {
                             JsonObject error = (new JsonObject()).put(Field.ERROR, err.getMessage());

--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -90,6 +90,7 @@ public class Field {
     public static final String JSNS = "jsns";
     public static final String BODY_LOWER_CASE = "body";
     public static final String MESSAGE_ID = "message_id";
+    public static final String EMAIL = "email";
     public static final String LOCAL_MAIL_ID = "local_mail_id";
     public static final String ZIMBRA = "zimbra";
     public static final String RECEIVERID = "receiverId";

--- a/zimbra/src/main/java/fr/openent/zimbra/core/enums/AddressType.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/enums/AddressType.java
@@ -1,0 +1,15 @@
+package fr.openent.zimbra.core.enums;
+
+public enum AddressType {
+    F("f");
+
+    private final String addressType;
+
+    AddressType(String addressType) {
+        this.addressType = addressType;
+    }
+
+    public String method() {
+        return this.addressType;
+    }
+}

--- a/zimbra/src/main/java/fr/openent/zimbra/core/enums/RecipientType.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/enums/RecipientType.java
@@ -1,0 +1,27 @@
+package fr.openent.zimbra.core.enums;
+
+import java.util.Objects;
+
+public enum RecipientType {
+    GROUP("group"),
+    USER("user"),
+    UNKNOWN("unknown");
+
+    private final String recipientType;
+
+    RecipientType(String recipientType) {
+        this.recipientType = recipientType;
+    }
+
+    public String method() {
+        return this.recipientType;
+    }
+
+    public static RecipientType fromString (String type) {
+        for (RecipientType recipientType : RecipientType.values()) {
+            if (Objects.equals(recipientType.method(), type))
+                return recipientType;
+        }
+        return RecipientType.UNKNOWN;
+    }
+}

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/ServiceManager.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/ServiceManager.java
@@ -151,7 +151,7 @@ public class ServiceManager {
         this.frontPageService = new FrontPageService(folderService, userService);
         this.returnedMailService = new ReturnedMailService(new DbMailServiceFactory(vertx, sqlSynchroService).getDbMailService("postgres"), messageService, userService, notificationService, eb);
         this.structureService = new StructureServiceImpl(neoService);
-        this.recallMailService = new RecallMailServiceImpl(sqlRecallMailService, messageService, recallQueueService, notificationService, structureService, recipientService);
+        this.recallMailService = new RecallMailServiceImpl(eb, sqlRecallMailService, messageService, recallQueueService, notificationService, structureService, recipientService, userService);
 
         this.synchroLauncher = new SynchroLauncher(synchroUserService, sqlSynchroService);
         this.synchroService = new SynchroService(sqlSynchroService, synchroLauncher);

--- a/zimbra/src/main/java/fr/openent/zimbra/model/message/Recipient.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/message/Recipient.java
@@ -1,12 +1,16 @@
 package fr.openent.zimbra.model.message;
 
+import fr.openent.zimbra.core.enums.RecipientType;
+
 public class Recipient {
     private String emailAddress;
     private String userId;
+    private RecipientType recipientType;
 
-    public Recipient(String emailAddress, String userId) {
+    public Recipient(String emailAddress, String userId, RecipientType recipientType) {
         this.emailAddress = emailAddress;
         this.userId = userId;
+        this.recipientType = recipientType;
     }
 
     public String getEmailAddress() {
@@ -16,4 +20,13 @@ public class Recipient {
     public String getUserId() {
         return userId;
     }
+
+    public RecipientType getRecipientType() {
+        return this.recipientType;
+    }
+
+    public void setRecipientType(RecipientType recipientType) {
+        this.recipientType = recipientType;
+    }
+
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/model/task/RecallTask.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/task/RecallTask.java
@@ -6,15 +6,13 @@ import fr.openent.zimbra.model.action.Action;
 import fr.openent.zimbra.model.message.RecallMail;
 import io.vertx.core.json.JsonObject;
 
-import java.util.UUID;
-
 public class RecallTask extends Task<RecallTask> {
     private final RecallMail recallMessage;
     private String receiverEmail;
-    private final UUID receiverId;
+    private final String receiverId;
     private final int retry;
 
-    public RecallTask(long id, TaskStatus status, Action<RecallTask> action, RecallMail recallMessage, UUID receiverId, String receiverEmail, int retry) {
+    public RecallTask(long id, TaskStatus status, Action<RecallTask> action, RecallMail recallMessage, String receiverId, String receiverEmail, int retry) {
         super(id, status, action);
         this.recallMessage = recallMessage;
         this.receiverEmail = receiverEmail;
@@ -29,7 +27,7 @@ public class RecallTask extends Task<RecallTask> {
         }
         try {
             this.id = dbData.getInteger(Field.ID, -1);
-            this.receiverId = UUID.fromString(dbData.getString(Field.RECEIVER_ID));
+            this.receiverId = dbData.getString(Field.RECEIVER_ID);
             this.retry = dbData.getInteger(Field.RETRY);
             this.receiverEmail = dbData.getString(Field.RECIPIENT_ADDRESS);
             this.recallMessage = recallMessage;
@@ -46,7 +44,7 @@ public class RecallTask extends Task<RecallTask> {
         return recallMessage;
     }
 
-    public UUID getReceiverId() {
+    public String getReceiverId() {
         return receiverId;
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -20,6 +20,7 @@ package fr.openent.zimbra.service.impl;
 import fr.openent.zimbra.Zimbra;
 import fr.openent.zimbra.core.constants.Field;
 import fr.openent.zimbra.core.enums.ErrorEnum;
+import fr.openent.zimbra.core.enums.RecipientType;
 import fr.openent.zimbra.helper.*;
 import fr.openent.zimbra.model.MailAddress;
 import fr.openent.zimbra.model.ZimbraUser;
@@ -382,9 +383,12 @@ public class MessageService {
             zimbraMails.remove(0);
             translateMaillistToUidlist(frontMsg, zimbraMails, addressMap, isReported, handler);
         } else {
-            Handler<String> translatedUuidHandler = userUuid -> {
-                if (userUuid == null) {
+            Handler<Recipient> translatedUuidHandler = recipient -> {
+                String userUuid;
+                if (recipient.getRecipientType() == RecipientType.UNKNOWN || recipient.getUserId() == null) {
                     userUuid = zimbraMail;
+                } else {
+                    userUuid = recipient.getUserId();
                 }
                 addressMap.put(zimbraMail, userUuid);
                 switch (type) {
@@ -421,7 +425,7 @@ public class MessageService {
             };
 
             if (addressMap.containsKey(zimbraMail)) {
-                translatedUuidHandler.handle(addressMap.get(zimbraMail));
+                translatedUuidHandler.handle(new Recipient(zimbraMail, addressMap.get(zimbraMail), RecipientType.USER));
             } else {
                 translateMail(zimbraMail, translatedUuidHandler);
             }
@@ -431,13 +435,7 @@ public class MessageService {
 
     public void translateMailFuture(String mail, Handler<AsyncResult<Recipient>> handler) {
         translateMail(mail, res -> {
-            Recipient recipient;
-            if (res == null) {
-                recipient = new Recipient(mail, mail);
-            } else {
-                recipient = new Recipient(mail, res);
-            }
-            handler.handle(Future.succeededFuture(recipient));
+            handler.handle(Future.succeededFuture(res));
         });
     }
 
@@ -449,28 +447,30 @@ public class MessageService {
      * @param mail    Zimbra mail
      * @param handler result handler
      */
-    private void translateMail(String mail, Handler<String> handler) {
+    private void translateMail(String mail, Handler<Recipient> handler) {
         try {
             String domain = mail.split("@")[1];
             if (!Zimbra.domain.equals(domain)) {
-                handler.handle(null);
+                handler.handle(new Recipient(mail, mail, RecipientType.UNKNOWN));
                 return;
             }
         } catch (Exception e) {
-            handler.handle(null);
+            handler.handle(new Recipient(mail, mail, RecipientType.UNKNOWN));
             return;
         }
         dbMailService.getNeoIdFromMail(mail, sqlResponse -> {
             if (sqlResponse.isLeft() || sqlResponse.right().getValue().isEmpty()) {
                 log.debug("no user in database for address : " + mail);
-                handler.handle(groupService.getGroupId(mail));
+                handler.handle(new Recipient(mail, groupService.getGroupId(mail), RecipientType.GROUP));
             } else {
                 JsonArray results = sqlResponse.right().getValue();
                 if (results.size() > 1) {
                     log.warn("More than one user id for address : " + mail);
                 }
-                String uuid = results.getJsonObject(0).getString(DbMailService.NEO4J_UID);
-                handler.handle(uuid);
+                JsonObject resultData = results.getJsonObject(0);
+                String uuid = resultData.getString(DbMailService.NEO4J_UID);
+                RecipientType recipientType = RecipientType.fromString(resultData.getString(Field.TYPE));
+                handler.handle(new Recipient(mail, uuid, recipientType));
             }
         });
     }
@@ -1080,13 +1080,13 @@ public class MessageService {
      * @param user              User infos
      * @param trashConstraint   boolean constraint that the message should be in trash
      */
-    public Future<Void> deleteMessages(List<String> messageIDs, UserInfos user, boolean trashConstraint) {
+    public Future<Void> deleteMessages(List<String> messageIDs, String userId, boolean trashConstraint) {
         Promise<Void> promise = Promise.promise();
         List<Future<Void>> futures = new ArrayList<>();
 
         List<List<String>> batchMessageIds = ArrayHelper.split(messageIDs, BATCH_SIZE);
         for (List<String> ids : batchMessageIds) {
-            futures.add(this.deleteBatchMessages(ids, user, trashConstraint));
+            futures.add(this.deleteBatchMessages(ids, userId, trashConstraint));
         }
 
         FutureHelper.all(futures)
@@ -1103,7 +1103,7 @@ public class MessageService {
      * @param user              User infos
      * @param trashConstraint   boolean constraint that the message should be in trash
      */
-    private Future<Void> deleteBatchMessages(List<String> messageIDs, UserInfos user, boolean trashConstraint) {
+    private Future<Void> deleteBatchMessages(List<String> messageIDs, String userId, boolean trashConstraint) {
         Promise<Void> promise = Promise.promise();
 
         JsonObject actionReq = new JsonObject()
@@ -1120,10 +1120,10 @@ public class MessageService {
                         .put(SoapConstants.ACTION, actionReq)
                         .put(SoapConstants.REQ_NAMESPACE, SoapConstants.NAMESPACE_MAIL));
 
-        soapService.callUserSoapAPI(convActionRequest, user, response -> {
-            if (response.isLeft()) {
-                log.error(String.format("[Zimbra@MessageService::deleteBatchMessages] failed to callUserSoapAPI: %s", response.left().getValue()));
-                promise.fail(response.left().getValue());
+        soapService.callUserSoapAPI(convActionRequest, userId, response -> {
+            if (response.failed()) {
+                log.error(String.format("[Zimbra@MessageService::deleteBatchMessages] failed to callUserSoapAPI: %s", response.cause().getMessage()));
+                promise.fail(response.cause().getMessage());
             } else {
                 promise.complete();
             }
@@ -1202,12 +1202,11 @@ public class MessageService {
         user.checkIfExists(userResponse -> {
             if (userResponse.failed()) {
                 log.error("[Zimbra] retrieveMailFromZimbra : Error while checking if user exists in Zimbra :" + userResponse.cause().getMessage());
-                result.handle(new Either.Right<>(new ArrayList<>()));
+                result.handle(new Either.Left<>(ErrorEnum.USER_NOT_DEFINED.method()));
             } else {
                 if (user.existsInZimbra()) {
                     // Etape 3 : On recherche en fonction de l'objet, de l'expéditeur, de la date et de la boite de réception le mail à supprimer
                     String query = "* NOT in:\"" + "Sent" + "\"" + " AND from:\"" + from_mail + "\"" + " AND msgid:\"" + msgid + "\"";
-                    log.info(query);
                     SoapSearchHelper.searchAllMailedConv(to_user_id, 0, query, event -> {
                         if (event.succeeded()) {
                             if (event.result().size() > 0) {
@@ -1254,6 +1253,7 @@ public class MessageService {
                 }
             } else {
                 log.error("[Zimbra] reccursiveSearch : Error while searching mails : " + event.cause().getMessage());
+                result.handle(new Either.Left<>(event.cause().getMessage()));
             }
         });
     }

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -1100,7 +1100,7 @@ public class MessageService {
      * Delete a batch of messages
      *
      * @param messageIDs        List of Message ID
-     * @param user              User infos
+     * @param userId            User id
      * @param trashConstraint   boolean constraint that the message should be in trash
      */
     private Future<Void> deleteBatchMessages(List<String> messageIDs, String userId, boolean trashConstraint) {

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/cron/ICalRequestCron.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/cron/ICalRequestCron.java
@@ -22,7 +22,6 @@ public class ICalRequestCron extends ControllerHelper implements Handler<Long> {
 
     @Override
     public void handle(Long event) {
-        log.info("[ZimbraConnector@ICalRequestCron] ICalRequestCron started");
         final JsonObject message = new JsonObject();
         message.put(Field.ACTION, QueueWorkerAction.SYNC_QUEUE);
         EventBusHelper.requestJsonObject(eb, ICalRequestWorker.class.getName(), message)

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/cron/RecallMailCron.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/cron/RecallMailCron.java
@@ -24,7 +24,6 @@ public class RecallMailCron implements Handler<Long> {
 
     @Override
     public void handle(Long event) {
-        log.info("[ZimbraConnector@RecallCron] RecallCron started");
         final JsonObject message = new JsonObject();
         message.put(Field.ACTION, QueueWorkerAction.SYNC_QUEUE);
         EventBusHelper.requestJsonObject(eb, RecallMailWorker.RECALL_MAIL_HANDLER_ADDRESS, message)

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/QueueService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/QueueService.java
@@ -312,9 +312,17 @@ public abstract class QueueService<T extends Task<T>> {
                 action = new Action<>(new JsonObject(taskData.getString(Field.ACTION)));
                 this.actionList.add(action);
             }
-            T newTask = createTaskFromData(taskData, action);
-            action.addTask(newTask);
-            taskList.add(newTask);
+            try {
+                T newTask = createTaskFromData(taskData, action);
+                action.addTask(newTask);
+                taskList.add(newTask);
+            } catch(Exception e) {
+                String errMessage = String.format("[Zimbra@%s::createTasksAndActionFromData]:  " +
+                                        "an error has occured while creating tasks: %s",
+                                this.getClass().getSimpleName(), e.getMessage());
+                log.error(errMessage);
+            }
+            
         }
         return taskList;
     }

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/RecallMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/RecallMailService.java
@@ -54,7 +54,7 @@ public interface RecallMailService {
      * @param recallMail
      * @return
      */
-    public Future<Void> deleteMessage (RecallMail recallMail, UserInfos user, String receiverEmail, String senderEmail);
+    public Future<Void> deleteMessage (RecallMail recallMail, String userId, String receiverEmail, String senderEmail);
 
     public Future<JsonArray> renderRecallMails(UserInfos user, JsonArray messageList);
 

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallMailServiceImpl.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallMailServiceImpl.java
@@ -136,7 +136,10 @@ public class RecallMailServiceImpl implements RecallMailService {
         Promise<Message> promise = Promise.promise();
         recipientService.getUserIdsFromEmails(message.getAllAddresses())
                 .compose(userMap -> {
-                    String senderMail = message.getEmailAddresses().stream().filter(mail -> mail.getAddrType().equals(ADDR_TYPE_FROM)).findFirst().get().getAddress();
+                    String senderMail = message.getEmailAddresses()
+                                                .stream()
+                                                .filter(mail -> mail.getAddrType().equals(ADDR_TYPE_FROM))
+                                                .findFirst().orElse(ZimbraEmail.fromZimbra(new JsonObject())).getAddress();
                     return handleGroups(userMap.get(senderMail).getUserId(), userMap);
                 })
                 .onSuccess(userMap -> {

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallQueueServiceImpl.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallQueueServiceImpl.java
@@ -15,7 +15,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
-import java.util.UUID;
 
 public class RecallQueueServiceImpl extends QueueService<RecallTask> {
     public RecallQueueServiceImpl(String schema, DbTaskService<RecallTask> dbTaskService, DbActionService dbActionService) {
@@ -31,7 +30,7 @@ public class RecallQueueServiceImpl extends QueueService<RecallTask> {
                 TaskStatus.PENDING,
                 action,
                 null,
-                UUID.fromString(data.getString(Field.RECEIVER_ID)),
+                data.getString(Field.RECEIVER_ID),
                 data.getString(Field.RECIPIENT_ADDRESS),
                 data.getInteger(Field.RETRY)));
     }
@@ -41,7 +40,7 @@ public class RecallQueueServiceImpl extends QueueService<RecallTask> {
         Message message = Message.fromZimbra(new JsonObject().put(Field.MID, recallData.getString(Field.MESSAGE_ID)));
         return new RecallTask(      taskData,
                                     action,
-                                    new RecallMail(taskData.getInteger(Field.RECALL_MAIL_ID), message,recallData.getString(Field.USER_MAIL))
+                                    new RecallMail(taskData.getInteger(Field.RECALL_MAIL_ID), message, recallData.getString(Field.USER_MAIL))
         );
     }
 

--- a/zimbra/src/main/java/fr/openent/zimbra/worker/QueueWorker.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/worker/QueueWorker.java
@@ -44,7 +44,16 @@ abstract class QueueWorker<T extends Task<T>> extends AbstractVerticle implement
         this.running = true;
         this.workerStatus = QueueWorkerStatus.RUNNING;
         while (this.running && !queue.isEmpty()) {
-            execute(this.queue.poll());
+            T task = this.queue.poll();
+            try {
+                execute(task);
+            } catch(Exception e) {
+                String errMessage = String.format("[Zimbra@%s::startQueue]:  " +
+                                    "an error has occurred while executing task: %s",
+                            this.getClass().getSimpleName(), e.getMessage());
+                    queueService.logFailureOnTask(task, errMessage);
+                    log.error(errMessage);
+            }
         }
     }
 


### PR DESCRIPTION
## Describe your changes
Update the way to retrieve mail receiver from groups. 
We are now retrieving each user to ask for the delete and no longer asking directly to the group because zimbra server does not know how to handle it.
Also add some exception catching.
## Checklist tests
- [x] Try to recall a mail for standard user
- [x] Try to recal email for a group  

## Issue ticket number and link
[ MZI-224 ]
https://jira.support-ent.fr/browse/MZI-224
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)