### PR TITLE
fix(mail): #MZI-225 display manual group names

### DIFF
--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -156,7 +156,7 @@ public class MessageService {
                 .onSuccess(usernames -> {
                     displayNames.forEach(displayName -> {
                         String username = usernames.get(displayName.getString(0));
-                        displayName.set(1, username);
+                        displayName.set(1, username == null ? displayName.getString(1) : username);
                     });
                     promise.complete();
                 })

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/QueueService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/QueueService.java
@@ -19,9 +19,6 @@ import org.apache.commons.lang3.NotImplementedException;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
 import java.util.*;
 
 /**


### PR DESCRIPTION
## Describe your changes
Updated the way to retrieve manual groups name, before this update they were not displayed correctly.
## Checklist tests
- [x] list messages sent to manual groups
## Issue ticket number and link
[ MZI-225 ]
https://jira.support-ent.fr/browse/MZI-225
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)