### PR TITLE
fix(recall): #MZI-226 delay task execution

### DIFF
--- a/zimbra/src/main/java/fr/openent/zimbra/core/enums/ErrorEnum.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/enums/ErrorEnum.java
@@ -20,9 +20,11 @@ public enum ErrorEnum {
     ERROR_NO_SUCH_MESSAGE("zimbra.recall.no.such.message"),
     ERROR_FETCHING_ACTION("zimbra.error.fetching.action"),
     ERROR_FETCHING_STRUCTURE("zimbra.error.fetching.structures"),
+    ERROR_EXECUTING_TASK("zimbra.error.executing.task"),
     FAIL_ACCEPT_RECALL("fail.acept.recall"),
     ADML_NO_RIGHT_STRUCTURES("adml.no.rights.on.structs"),
     FAIL_DELETE_RECALL("fail.delete.recall"),
+    FAIL_DELETE_MAIL("fail.delete.mail"),
     FAIL_LIST_STRUCTURES("fail.list.structures"),
     ERROR_FETCHING_ADML("zimbra.error.fetching.adml"),
     ERROR_RETRIEVING_ACTION("zimbra.error.retrieving.action"),
@@ -35,7 +37,8 @@ public enum ErrorEnum {
     USER_NOT_DEFINED("user.not.defined"),
     ERROR_RETRIEVING_ICAL("error.retrieving.ical"),
     ERROR_CREATING_LOGS("error.creating.logs"),
-    NO_MAIL_TO_RECALL("no.mail.to.recall");
+    NO_MAIL_TO_RECALL("no.mail.to.recall"),
+    MAIL_NOT_FOUND("mail.not.found");
 
     private final String errorEnum;
 

--- a/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallMailServiceImpl.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/tasks/service/impl/RecallMailServiceImpl.java
@@ -353,7 +353,7 @@ public class RecallMailServiceImpl implements RecallMailService {
                     if (!mail.isEmpty()) {
                         return messageService.deleteMessages(mail, userId, false);
                     } else {
-                        return Future.succeededFuture();
+                        return Future.failedFuture(ErrorEnum.MAIL_NOT_FOUND.method());
                     }
                 })
                 .onSuccess(promise::complete)
@@ -362,7 +362,8 @@ public class RecallMailServiceImpl implements RecallMailService {
                                     "error while deleting mail: %s",
                             this.getClass().getSimpleName(), err.getMessage());
                     log.error(errMessage);
-                    promise.fail(ErrorEnum.ERROR_DELETING_MAIL.method());
+                    ErrorEnum error = err.getMessage().equals(ErrorEnum.MAIL_NOT_FOUND.method()) ? ErrorEnum.MAIL_NOT_FOUND : ErrorEnum.ERROR_RETRIEVING_MAIL;
+                    promise.fail(error.method());
                 });
 
         return promise.future();

--- a/zimbra/src/main/java/fr/openent/zimbra/worker/RecallMailWorker.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/worker/RecallMailWorker.java
@@ -4,8 +4,9 @@ import fr.openent.zimbra.core.enums.ErrorEnum;
 import fr.openent.zimbra.core.enums.TaskStatus;
 import fr.openent.zimbra.model.task.RecallTask;
 import fr.openent.zimbra.tasks.service.RecallMailService;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.logging.LoggerFactory;
-import org.entcore.common.user.UserUtils;
 
 public class RecallMailWorker extends QueueWorker<RecallTask> {
     public final RecallMailService recallMailService = serviceManager.getRecallMailService();
@@ -23,23 +24,41 @@ public class RecallMailWorker extends QueueWorker<RecallTask> {
         this.eb.localConsumer(RECALL_MAIL_HANDLER_ADDRESS, this);
     }
 
-    public void execute(RecallTask task) {
+    private void handleDeleteMailError(RecallTask task, String err) {
+        if (!err.equals(ErrorEnum.MAIL_NOT_FOUND.method()) || task.getRetry() < 4) {
+            queueService.logFailureOnTask(task, ErrorEnum.ERROR_UPDATING_TASK.method())
+                    .onFailure(error -> {
+                        String errMessage = String.format("[Zimbra@%s::handleDeleteMailError]:  " +
+                                "an error has occurred while updating task status: %s",
+                                this.getClass().getSimpleName(), error.getMessage());
+                        log.error(errMessage);
+                    });
+        } else {
+            queueService.editTaskStatus(task, TaskStatus.FINISHED)
+                    .onFailure(error -> {
+                        String errMessage = String.format("[Zimbra@%s::handleDeleteMailError]:  " +
+                                "an error has occurred while updating task status: %s",
+                                this.getClass().getSimpleName(), error.getMessage());
+                        log.error(errMessage);
+                    });
+        }
+    }
+
+    public Future<Void> execute(RecallTask task) {
+        Promise<Void> promise = Promise.promise();
         recallMailService
                 .deleteMessage(task.getRecallMessage(), task.getReceiverId(), task.getReceiverEmail(),
                         task.getRecallMessage().getSenderEmail())
                 .compose(isDeleted -> queueService.editTaskStatus(task, TaskStatus.FINISHED))
+                .onSuccess(res -> promise.complete())
                 .onFailure(err -> {
-                    queueService.logFailureOnTask(task, ErrorEnum.ERROR_UPDATING_TASK.method())
-                            .onFailure(error -> {
-                                String errMessage = String.format("[Zimbra@%s::execute]:  " +
-                                        "an error has occurred while updating task status: %s",
-                                        this.getClass().getSimpleName(), error.getMessage());
-                                log.error(errMessage);
-                            });
+                    handleDeleteMailError(task, err.getMessage());
+                    promise.fail(ErrorEnum.ERROR_EXECUTING_TASK.method());
                     String errMessage = String.format("[Zimbra@%s::execute]:  " +
                             "an error has occurred while executing recall task: %s",
                             this.getClass().getSimpleName(), err.getMessage());
                     log.error(errMessage);
                 });
+        return promise.future();
     }
 }


### PR DESCRIPTION
## Describe your changes
Context: 
To recall mail to different recipient, we treat it as tasks. Each recipient is a task and the task is execute in a queue as FIFO. We noticied that zimbra server struggled to handle too many request at the same time, especially when the recipient remains the same.
Solution:
Now the queue will wait for the previous task to complete before executing the new one.
## Checklist tests
- [x] Recall 20 mails to the same sender
## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)