### PR TITLE
feat(message): #MZI-232 add read toggle option

### DIFF
--- a/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/controllers/ZimbraController.java
@@ -722,13 +722,15 @@ public class ZimbraController extends BaseController {
     @SecuredAction(value = "zimbra.message", type = ActionType.AUTHENTICATED)
     public void getMessage(final HttpServerRequest request) {
         final String id = request.params().get(MESSAGE_ID);
+        final String setReadValue = request.params().get(Field.SETREAD);
+        final Boolean setRead = setReadValue != null ? Boolean.parseBoolean(setReadValue) : null;
         if (id == null || id.trim().isEmpty()) {
             badRequest(request);
             return;
         }
         getUserInfos(eb, request, user -> {
             if (user != null) {
-                messageService.getMessage(id, user, defaultResponseHandler(request));
+                messageService.getMessage(id, user, setRead, defaultResponseHandler(request));
             } else {
                 unauthorized(request);
             }

--- a/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/core/constants/Field.java
@@ -25,6 +25,7 @@ public class Field {
     public static final String STATUS = "status";
     public static final String STATUT = "statut";
     public static final String SUCCESS = "success";
+    public static final String SETREAD = "setRead";
     public static final String ID = "id";
     public static final String MID = "mid";
     public static final String IDS = "ids";

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/AttachmentService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/AttachmentService.java
@@ -398,7 +398,7 @@ public class AttachmentService {
      */
     public void removeAttachment(String messageId, String attachmentId, UserInfos user,
                                  Handler<Either<String, JsonObject>> result) {
-        messageService.getMessage(messageId, user, response -> {
+        messageService.getMessage(messageId, user, null, response -> {
             if (response.isLeft()) {
                 result.handle(new Either.Left<>(response.left().getValue()));
             } else {
@@ -430,7 +430,7 @@ public class AttachmentService {
 
     public void forwardAttachments(String origMessageId, String finalMessageid, UserInfos user,
                                    Handler<Either<String, JsonObject>> handler) {
-        messageService.getMessage(origMessageId, user, response -> {
+        messageService.getMessage(origMessageId, user, null, response -> {
             if (response.isLeft()) {
                 handler.handle(new Either.Left<>(response.left().getValue()));
             } else {
@@ -462,7 +462,7 @@ public class AttachmentService {
      */
     private void updateDraft(String messageId, String uploadAttchId, UserInfos user, JsonArray forwardedAtts,
                             Handler<Either<String, JsonObject>> result) {
-        messageService.getMessage(messageId, user, response -> {
+        messageService.getMessage(messageId, user, null, response -> {
             if (response.isLeft()) {
                 result.handle(new Either.Left<>(response.left().getValue()));
             } else {

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/MessageService.java
@@ -494,10 +494,10 @@ public class MessageService {
      * @param user      User infos
      * @param handler   Final handler
      */
-    public void getMessage(String messageId, UserInfos user, Handler<Either<String, JsonObject>> handler) {
+    public void getMessage(String messageId, UserInfos user, Boolean setRead, Handler<Either<String, JsonObject>> handler) {
         JsonObject messageReq = new JsonObject()
                 .put("html", 1)
-                .put("read", Zimbra.appConfig.isActionBlocked(ConfigManager.UPDATE_ACTION) ? 0 : 1)
+                .put("read", setRead != null ? setRead : Zimbra.appConfig.isActionBlocked(ConfigManager.UPDATE_ACTION) ? 0 : 1)
                 .put("needExp", 1)
                 .put("neuter", 0)
                 .put(Field.ID, messageId);

--- a/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/impl/ReturnedMailService.java
@@ -52,7 +52,7 @@ public class ReturnedMailService {
         String messagesId = body.getString(MESSAGE_ID);
         String comment = body.getString(ZIMBRA_COMMENT);
         // Etape 1 : récupérer le message à supprimer
-        messageService.getMessage(messagesId, user, getMail -> {
+        messageService.getMessage(messagesId, user, null, getMail -> {
             if (getMail.isRight()) {
                 JsonObject mail = getMail.right().getValue();
                 if (!Objects.equals(mail.getString(MAIL_FROM), user.getUserId())) {


### PR DESCRIPTION
## Describe your changes
We added a query parameter to the route "/zimbra/message/:id" to enable user to retreive the mail without setting it to read status.  
API documentation: https://confluence.support-ent.fr/display/ZIM/Messages
## Checklist tests
- [x] Read the mail without the new param and see its status set to read
- [x] Read the mail with the ew param set to false and see it unread
## Issue ticket number and link
[ MZI-232 ]
https://jira.support-ent.fr/browse/MZI-232
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)