### PR TITLE
fix(scroll) : #MZI-189 fix scroll when lot of mails already scrolled

### DIFF
--- a/zimbra/src/main/resources/public/sass/global/_conversation.scss
+++ b/zimbra/src/main/resources/public/sass/global/_conversation.scss
@@ -62,7 +62,7 @@
 
   div.scroll-list {
     max-height: 600px;
-    overflow-y: scroll;
+    overflow-y: auto;
 
     ::-webkit-scrollbar-track {
       -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);

--- a/zimbra/src/main/resources/public/sass/index.scss
+++ b/zimbra/src/main/resources/public/sass/index.scss
@@ -3,3 +3,4 @@
 @import "./entcore-css-lib/scss/index.scss";
 
 @import "global/conversation";
+@import "global/setting";

--- a/zimbra/src/main/resources/public/ts/directives/ngBottomScroll.ts
+++ b/zimbra/src/main/resources/public/ts/directives/ngBottomScroll.ts
@@ -24,6 +24,8 @@ export const ngBottomScroll = ng.directive('ngBottomScroll',  () => {
             element.bind('scroll', function () {
                 if (MyElement.scrollTop + MyElement.offsetHeight >= MyElement.scrollHeight - 1) {
                     scope.$apply(attrs.ngBottomScroll)
+                    const adjustment = MyElement.offsetHeight / 10; //When scrolling to the bottom, scroll up a 10% of the visible height to prevent to trigger the event again
+                    MyElement.scrollTop -= adjustment;
                 }
             })
         }


### PR DESCRIPTION
## Describe your changes
Fixed an issue where when you scrolled too much mails, the infinit scroll event was triggered again in a loop
## Checklist tests
In a folder with a lot of mail try to scroll a lot without stopping, and check if mail keep getting loaded
## Issue ticket number and link
[MZI-189](https://jira.support-ent.fr/browse/MZI-189)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)