### PR TITLE
fix(move-mail): #MZI-192 fix move mail from parent to a sub folder

### DIFF
--- a/zimbra/src/main/resources/public/sass/global/_conversation.scss
+++ b/zimbra/src/main/resources/public/sass/global/_conversation.scss
@@ -15,7 +15,14 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-.zimbra {
+.zimbra-module {
+
+  .disabled-link{
+    pointer-events: none;
+    cursor: default;
+    opacity: 0.5;
+  }
+
   .info {
     margin-top: 55px;
   }
@@ -388,4 +395,5 @@
     display: list-item !important;
     font-size: 13px !important;
   }
+
 }

--- a/zimbra/src/main/resources/public/template/move-mail.html
+++ b/zimbra/src/main/resources/public/template/move-mail.html
@@ -17,24 +17,22 @@
 
  <!-- Folders - move popup templates -->
 
- <script type="text/ng-template" id="move-folders-content">
-
-	 <a ng-click="destination.folder = folder; moveToFolderClick(folder, obj); folder.selected = !folder.selected"
-		 ng-init="obj = { template: '' }"
-		 ng-class="{ selected: destination.folder.id === folder.id, opened: isOpenedFolder(folder)  }"
-		 class="folder-list-item">
+<script type="text/ng-template" id="move-folders-content">
+	<a ng-click="destination.folder = folder; moveToFolderClick(folder, obj); folder.selected = !folder.selected"
+	   ng-init="obj = { template: '' }; showSubFolderIfCurrent(folder, obj);"
+	   ng-class="{ selected: destination.folder.id === folder.id, opened: isOpenedFolder(folder), 'disabled-link': folder.id === zimbra.currentFolder.id, opened: folder.id === zimbra.currentFolder.id}"
+	   class="folder-list-item">
 		<i class="arrow" ng-if="folder.userFolders.all.length"></i>
 		<span ng-if="!folders.list.includes(folder)">[[folder.name]]</span>
 		<span ng-if="folders.list.includes(folder)">[[lang.translate(folder.folderName)]]</span>
-
- 	</a>
- 	<ul ng-class="{ selected: destination.folder.id === folder.id, closed: isClosedFolder(folder) }"
-		 ng-if="isOpenedFolder(folder)">
+	</a>
+	<ul ng-class="{ selected: destination.folder.id === folder.id, closed: isClosedFolder(folder) && folder.id !== zimbra.currentFolder.id }"
+		ng-if="isOpenedFolder(folder) || folder.id === zimbra.currentFolder.id">
 		<li data-ng-repeat="folder in folder.userFolders.all | orderBy : 'name'"
- 			data-ng-include="obj.template">
- 		</li>
- 	</ul>
- </script>
+			data-ng-include="obj.template">
+		</li>
+	</ul>
+</script>
  <script type="text/ng-template" id="move-folders-root">
 	 <div ng-if="(!folders.list.includes(zimbra.currentFolder) || zimbra.currentFolder.folderName === 'trash' || zimbra.currentFolder.folderName === 'spams')">
 		 <h3><i18n>messages</i18n></h3>
@@ -45,7 +43,7 @@
 
 	 <h3><i18n>user.folders</i18n></h3>
 	 <ul>
-		 <li ng-repeat="folder in userFolders.all" ng-include="'move-folders-content'" ng-if="zimbra.currentFolder.id != folder.id"></li>
+		 <li ng-repeat="folder in userFolders.all" ng-include="'move-folders-content'"></li>
 	 </ul>
  </script>
 

--- a/zimbra/src/main/resources/public/ts/controllers/controller.ts
+++ b/zimbra/src/main/resources/public/ts/controllers/controller.ts
@@ -832,6 +832,12 @@ export let zimbraController = ng.controller("ZimbraController", [
             }, 10);
         };
 
+        $scope.showSubFolderIfCurrent = (folder: UserFolder, obj: { template: string }) => {
+            if(folder.id == Zimbra.instance.currentFolder.id) {
+                $scope.moveToFolderClick(folder, obj)
+            }
+        }
+
         $scope.recallMail = async (id: string, comment: string) => {
             $scope.lightbox.show = false;
             template.close("lightbox");

--- a/zimbra/src/main/resources/public/ts/model/folder.ts
+++ b/zimbra/src/main/resources/public/ts/model/folder.ts
@@ -250,7 +250,7 @@ export class Draft extends SystemFolder {
             get: `/zimbra/list?folder=${encodeURIComponent(path)}`
         });
 
-        this.folderName = "draft";
+        this.folderName = "drafts";
         this.nbUnread = unread;
         this.count = count;
         this.folders = folders;

--- a/zimbra/src/main/resources/public/ts/model/mail.ts
+++ b/zimbra/src/main/resources/public/ts/model/mail.ts
@@ -510,7 +510,7 @@ export class Mail implements Selectable {
                     this.attachments = this.attachments.concat(attachmentWaiting);
                     this.newAttachments = null;
                 })
-                .catch((e: AxiosError) => {
+                .catch((e: AxiosError<any>) => {
                     // remove attachment
                     this.attachments = this.attachments.filter((attachment: Attachment) => {
                         return attachment.filename !== attachmentToUpload.filename || attachment.id;
@@ -532,7 +532,7 @@ export class Mail implements Selectable {
             .then(() => {
                 notify.info("zimbra.attachment.download.workspace.success");
             })
-            .catch((e : AxiosError) => {
+            .catch((e : AxiosError<any>) => {
                 sendNotificationErrorZimbra(e.response.data.error);
             });
     }

--- a/zimbra/src/main/resources/view-src/error.html
+++ b/zimbra/src/main/resources/view-src/error.html
@@ -24,7 +24,7 @@
   <script src="/assets/js/entcore/ng-app.js?v=@@VERSION" type="text/javascript" id="context"></script>
     <link rel="stylesheet" href="/zimbra/public/css/conversation.css?v=@@VERSION">
 </head>
-<body class="zimbra">
+<body class="zimbra-module">
 <portal>
     <div class="emptyscreen">
         <h2 class="empty-screen-header">{{#i18n}}zimbra.view.error.title{{/i18n}}</h2>

--- a/zimbra/src/main/resources/view-src/print.html
+++ b/zimbra/src/main/resources/view-src/print.html
@@ -25,7 +25,7 @@
   <style> header {display : none}</style>
   <link rel="stylesheet" href="/zimbra/public/css/conversation.css?v=@@VERSION">
 </head>
-<body ng-controller="PrintController" class="zimbra">
+<body ng-controller="PrintController" class="zimbra-module">
     <portal>
         <div class="twelve cell line">
             <div class="row">

--- a/zimbra/src/main/resources/view-src/zimbra.html
+++ b/zimbra/src/main/resources/view-src/zimbra.html
@@ -51,7 +51,7 @@
   <script src="/zimbra/public/dist/application.js?v=@@VERSION" type="text/javascript"></script>
   <link rel="stylesheet" href="/zimbra/public/css/conversation.css?v=@@VERSION">
 </head>
-<body ng-controller="ZimbraController" class="zimbra">
+<body ng-controller="ZimbraController" class="zimbra-module">
 <portal>
     <div ng-class="{info: quotaMessage.percent < 100, warning: quotaMessage.percent >= 100}" ng-init="initQuotaMessage()" ng-show="quotaMessage.active">
         <span ng-if="quotaMessage.percent < 100"><i18n>zimbra.quota.info.message</i18n></span>


### PR DESCRIPTION
## Describe your changes
Fix an issue where subfolder wasnt shown in move mail lightbox if the mail was in the parent folder.

![image](https://github.com/OPEN-ENT-NG/zimbra-connector/assets/57497688/009b872a-ea32-4415-8623-8ba1302237e3)

## Checklist tests
Select a mail from a folder that have subfolder, try to move it and check if the sub folders appear in the lightbox
## Issue ticket number and link
[MZI-192](https://jira.support-ent.fr/browse/MZI-192)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)