### PR TITLE
fix(scroll): #MZI-189 fix last mail scroll when no more elements

### DIFF
--- a/zimbra/src/main/resources/public/ts/directives/ngBottomScroll.ts
+++ b/zimbra/src/main/resources/public/ts/directives/ngBottomScroll.ts
@@ -24,8 +24,13 @@ export const ngBottomScroll = ng.directive('ngBottomScroll',  () => {
             element.bind('scroll', function () {
                 if (MyElement.scrollTop + MyElement.offsetHeight >= MyElement.scrollHeight - 1) {
                     scope.$apply(attrs.ngBottomScroll)
-                    const adjustment = MyElement.offsetHeight / 10; //When scrolling to the bottom, scroll up a 10% of the visible height to prevent to trigger the event again
-                    MyElement.scrollTop -= adjustment;
+                    let previousScrollHeight = MyElement.scrollHeight;
+                    setTimeout( () => {
+                        if (MyElement.scrollHeight > previousScrollHeight) {
+                            const adjustment = MyElement.offsetHeight / 10; //When scrolling to the bottom, scroll up a 10% of the visible height to prevent to trigger the event again
+                            MyElement.scrollTop -= adjustment;
+                        }
+                    }, 10);
                 }
             })
         }


### PR DESCRIPTION
## Describe your changes
Fixed the issue caused by the scroll-up adjustment where the last email was hidden.
## Checklist tests
Scroll all the way down to the last email in a folder and check if it displays correctly.
## Issue ticket number and link
[MZI-189](https://jira.support-ent.fr/browse/MZI-189)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)