### PR TITLE
fix(image): #MZI-212 fix external image in mail body

### DIFF
--- a/zimbra/deployment/zimbra/conf.json.template
+++ b/zimbra/deployment/zimbra/conf.json.template
@@ -57,6 +57,10 @@
       "api-token": "$zimbraSlackApiToken",
       "channel": "$zimbraSlackChannel",
       "bot-username": "$zimbraSlackBotUsername"
+    },
+    "zimbra-document-config": {
+        "cid-patern": "$zimbraCidPattern",
+        "document-download-endpoint" : "$zimbraDocumentEndpoint"
     }
   }
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/CidHelper.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/CidHelper.java
@@ -1,0 +1,68 @@
+package fr.openent.zimbra.helper;
+
+import fr.openent.zimbra.Zimbra;
+import fr.openent.zimbra.model.constant.FrontConstants;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static fr.openent.zimbra.model.constant.FrontConstants.MESSAGE_BODY;
+
+public class CidHelper {
+    private static final Logger log = LoggerFactory.getLogger(CidHelper.class);
+    private static final Pattern pattern = Zimbra.appConfig.getCidPattern();
+
+    private CidHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static List<String> getMessageCids(JsonObject message){
+        try {
+            Matcher matcher = pattern.matcher(message.getString(MESSAGE_BODY));
+            List<String> cids = new ArrayList<>();
+            while (matcher.find()) {
+                cids.add(matcher.group(1));
+            }
+            return cids;
+        } catch (NullPointerException npe) {
+            String errMessage = "[Zimbra@CidHelper::getMessageCids] Failed to get message cids for pattern " + pattern;
+            log.error(errMessage + " : " + npe.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    public static Map<String, String> mapCidToImageUrl(String messageId, List<String> cids){
+        String zimbraUrlGetImage = Zimbra.appConfig.getZimbraUri() + Zimbra.appConfig.getZimbraDocumentConfig().getDocumentDownloadEndpoint();
+
+        HashMap<String, String> mapCidToImageUrl = new HashMap<>();
+        int partCount = 2;
+        for(String cid : cids){
+            String imageUrl = zimbraUrlGetImage + messageId + "&part=" + partCount;
+            mapCidToImageUrl.put(cid, imageUrl);
+            partCount++;
+        }
+        return mapCidToImageUrl;
+    }
+
+    public static Map<String,String> mapCidToBase64(Map<String,Buffer> mapCidToImageBuffer){
+        HashMap<String, String> mapCidToBase64Images = new HashMap<>();
+
+        mapCidToImageBuffer.forEach((cid, imageBuffer) -> mapCidToBase64Images.put(cid, Base64.getEncoder().encodeToString(imageBuffer.getBytes())));
+
+        return mapCidToBase64Images;
+    }
+
+    public static JsonObject replaceCidByBase64(JsonObject message, Map<String, String> mapCidToBase64){
+        String body = message.getString(MESSAGE_BODY);
+        for (String cid : mapCidToBase64.keySet()){
+            body = body.replace("cid:" + cid, "data:image/png;base64," + mapCidToBase64.get(cid));
+        }
+        message.put(MESSAGE_BODY, body);
+        return message;
+    }
+}

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/ConfigManager.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/ConfigManager.java
@@ -17,12 +17,22 @@
 
 package fr.openent.zimbra.helper;
 
+import fr.openent.zimbra.Zimbra;
+import fr.openent.zimbra.model.DocumentConfiguration;
 import fr.openent.zimbra.model.SlackConfiguration;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static fr.openent.zimbra.model.constant.FrontConstants.MESSAGE_BODY;
 
 @SuppressWarnings("WeakerAccess")
 public class ConfigManager {
@@ -97,6 +107,8 @@ public class ConfigManager {
     private CircuitBreakerOptions circuitBreakerOptions;
 
     private SlackConfiguration slackConfiguration;
+
+    private final DocumentConfiguration zimbraDocumentConfig;
 
     private static final Logger log = LoggerFactory.getLogger(ConfigManager.class);
 
@@ -175,6 +187,7 @@ public class ConfigManager {
         this.circuitBreakerOptions = new CircuitBreakerOptions(config.getJsonObject("circuit-breaker", new JsonObject()));
         JsonObject slackConfig = config.getJsonObject("slack", new JsonObject());
         this.slackConfiguration = new SlackConfiguration(slackConfig.getString("api-uri", ""), slackConfig.getString("api-token", ""), slackConfig.getString("channel", ""), slackConfig.getString("bot-username", ""), config.getString("host", ""));
+        this.zimbraDocumentConfig = new DocumentConfiguration(config.getJsonObject("zimbra-document-config", new JsonObject()));
         initPublicConfig();
     }
 
@@ -242,5 +255,21 @@ public class ConfigManager {
         }
         return newpwd;
     }
+
+    public DocumentConfiguration getZimbraDocumentConfig() {
+        return zimbraDocumentConfig;
+    }
+
+    public Pattern getCidPattern() {
+        try {
+            return Pattern.compile(zimbraDocumentConfig.getCidPattern());
+        }
+        catch (PatternSyntaxException pse) {
+            String errMessage = "[Zimbra@ConfidManager::getCidPattern] Failed to compile cid pattern from config";
+            log.error(errMessage + " : " + pse.getMessage());
+            throw new RuntimeException(pse);
+        }
+    }
+
 
 }

--- a/zimbra/src/main/java/fr/openent/zimbra/helper/ServiceManager.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/helper/ServiceManager.java
@@ -99,6 +99,8 @@ public class ServiceManager {
 
     private CalendarServiceImpl calendarService;
 
+    private HttpService httpService;
+
     private ServiceManager(Vertx vertx, EventBus eb, String pathPrefix, ConfigManager config) {
         this.vertx = vertx;
         JsonObject rawConfig = config != null ? config.getRawConfig() : null;
@@ -138,8 +140,9 @@ public class ServiceManager {
         this.neoService = new Neo4jZimbraService();
         this.folderService = new FolderService(soapService);
         this.signatureService = new SignatureService(userService, soapService);
+        this.httpService = new HttpService(vertx);
         this.messageService = new MessageService(soapService, folderService,
-                dbMailServiceApp, userService, synchroUserService);
+                dbMailServiceApp, userService, synchroUserService, httpService);
         this.recipientService = new RecipientService(messageService);
         if (rawConfig != null) this.attachmentService = new AttachmentService(soapService, messageService, vertx, rawConfig, webClient);
         this.notificationService = new NotificationService(pathPrefix, timelineHelper);

--- a/zimbra/src/main/java/fr/openent/zimbra/model/DocumentConfiguration.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/model/DocumentConfiguration.java
@@ -1,0 +1,35 @@
+package fr.openent.zimbra.model;
+
+import io.vertx.core.json.JsonObject;
+
+public class DocumentConfiguration {
+    private String cidPattern;
+    private String documentDownloadEndpoint;
+
+    public DocumentConfiguration(JsonObject documentConfig) {
+        this.cidPattern = documentConfig.getString("cid-patern", "cid:(.*?)\"");
+        this.documentDownloadEndpoint = documentConfig.getString("document-download-endpoint", "/service/home/~/?auth=co&loc=fr_FR&id=");
+    }
+
+    // Getter
+
+    public String getCidPattern() {
+        return cidPattern;
+    }
+
+    public String getDocumentDownloadEndpoint() {
+        return documentDownloadEndpoint;
+    }
+
+    // Setter
+
+    public DocumentConfiguration setCidPattern(String cidPattern) {
+        this.cidPattern = cidPattern;
+        return this;
+    }
+
+    public DocumentConfiguration setDocumentDownloadEndpoint(String documentDownloadEndpoint) {
+        this.documentDownloadEndpoint = documentDownloadEndpoint;
+        return this;
+    }
+}

--- a/zimbra/src/main/java/fr/openent/zimbra/service/data/HttpService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/data/HttpService.java
@@ -1,0 +1,48 @@
+package fr.openent.zimbra.service.data;
+
+import io.vertx.core.Future;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.web.client.HttpRequest;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+
+import java.util.Map;
+
+public class HttpService {
+
+    private final Vertx vertx;
+    private final WebClient client;
+    private static final Logger log = LoggerFactory.getLogger(HttpService.class);
+
+    public HttpService(Vertx vertx) {
+        this.vertx = vertx;
+        this.client = WebClient.create(vertx);
+    }
+
+    public Future<Buffer> get(String url, Map<String, String> headers) {
+        Promise<Buffer> promise = Promise.promise();
+
+        client.getAbs(url)
+                .putHeaders(MultiMap.caseInsensitiveMultiMap().addAll(headers))
+                .send((ar -> {
+                    if (ar.succeeded()) {
+                        HttpResponse<Buffer> response = ar.result();
+                        if (response.statusCode() == 200) {
+                            promise.complete(response.body());
+                        } else {
+                            log.error(String.format("Zimbra@getRequest : error received non-200 response %s", response.statusCode()));
+                            promise.fail("Received non-200 response: " + response.statusCode());
+                        }
+                    } else {
+                        promise.fail(ar.cause());
+                    }
+                }));
+
+        return promise.future();
+    }
+}

--- a/zimbra/src/main/java/fr/openent/zimbra/service/data/SoapZimbraService.java
+++ b/zimbra/src/main/java/fr/openent/zimbra/service/data/SoapZimbraService.java
@@ -31,10 +31,7 @@ import fr.openent.zimbra.service.synchro.SynchroUserService;
 import fr.wseduc.webutils.Either;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
@@ -666,5 +663,19 @@ public class SoapZimbraService {
         getAuthToken(userId, userAddress, false, handler);
     }
 
+    public Future<String> getUserAuthToken(UserInfos user) {
+        Promise<String> promise = Promise.promise();
+
+        getUserAuthToken(user, authTokenResponse -> {
+            if (authTokenResponse.isLeft()) {
+                log.error(String.format("Zimbra@getUserAuthToken : error with user token: %s", authTokenResponse.left().getValue()));
+                promise.fail(authTokenResponse.left().getValue());
+            } else {
+                promise.complete(authTokenResponse.right().getValue().getString(Field.AUTH_TOKEN));
+            }
+        });
+
+        return promise.future();
+    }
 
 }

--- a/zimbra/src/test/java/fr/openent/zimbra/helper/CidHelperTest.java
+++ b/zimbra/src/test/java/fr/openent/zimbra/helper/CidHelperTest.java
@@ -1,0 +1,39 @@
+package fr.openent.zimbra.helper;
+
+import fr.openent.zimbra.Zimbra;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static fr.openent.zimbra.model.constant.FrontConstants.MESSAGE_BODY;
+
+
+@RunWith(VertxUnitRunner.class)
+public class CidHelperTest {
+
+    @Before
+    public void before(){
+        ConfigManager cm = new ConfigManager(new JsonObject());
+        Zimbra.appConfig = cm;
+    }
+    @Test
+    public void testGetCids_shouldSucceed (TestContext ctx) {
+        JsonObject emptyMessage = new JsonObject();
+        JsonObject message = new JsonObject().put(MESSAGE_BODY, "dfhskjhfksfhsrc=\"cid:ciddetest\"");
+
+        List<String> emptyCids = CidHelper.getMessageCids(emptyMessage);
+        List<String> oneCid = CidHelper.getMessageCids(message);
+
+        List<String> oneCidTest = new ArrayList<>();
+        oneCidTest.add("ciddetest");
+
+        ctx.assertEquals(emptyCids, new ArrayList<String>());
+        ctx.assertEquals(oneCid, oneCidTest);
+    }
+}

--- a/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/MessageServiceTest.java
+++ b/zimbra/src/test/java/fr/openent/zimbra/service/test/impl/MessageServiceTest.java
@@ -39,7 +39,7 @@ public class MessageServiceTest {
     public void setUp() {
         this.userService = Mockito.mock(UserService.class);
         PowerMockito.spy(MessageService.class);
-        this.messageService = PowerMockito.spy(new MessageService(null, null, null, userService, null));
+        this.messageService = PowerMockito.spy(new MessageService(null, null, null, userService, null, null));
     }
 
     @Test


### PR DESCRIPTION
## Describe your changes
Fix issue where images in mail body from external senders where not displayed in zimbra but were displayed in expert mode

Now when the user try to read the mail we retrieve images from zimbra rest api, encode them in base64 and replace them in the mail body.

There is 2 new conf needed : 
- **$zimbraCidPattern** : A regex to match a content-id, cid are footprint of image from external mail client. they are used as the source of the image but are not recognize by our implementation of zimbra. That's why we replace them by base64 images retrieved with zimbra rest api.
- **$zimbraDocumentEndpoint** : the endpoint to retrieve image from zimbra server
The value of these 2 new confs are :

zimbraCidPattern='cid:(.*?)\"'
zimbraDocumentEndpoint='/service/home/~/?auth=co&loc=fr_FR&id=' 
## Checklist tests
Send a mail from another client (Outlook, Thunderbird...) with a image in body (Copy/Paste it into the mail not attachement). Then in Zimbra check if the image is displayed correctly.  
## Issue ticket number and link
[MZI-212](https://jira.support-ent.fr/browse/MZI-212)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)