### PR TITLE
fix(scroll): #MZI-189 fix mail scroll when lot of elements

### DIFF
--- a/zimbra/src/main/resources/public/ts/directives/ngBottomScroll.ts
+++ b/zimbra/src/main/resources/public/ts/directives/ngBottomScroll.ts
@@ -16,23 +16,31 @@
  */
 
 import { ng, _ } from "entcore";
-export const ngBottomScroll = ng.directive('ngBottomScroll',  () => {
+
+export const ngBottomScroll = ng.directive('ngBottomScroll', function () {
     return {
         restrict: 'A',
         link: function (scope, element, attrs) {
-            let MyElement = element[0];
-            element.bind('scroll', function () {
-                if (MyElement.scrollTop + MyElement.offsetHeight >= MyElement.scrollHeight - 1) {
-                    scope.$apply(attrs.ngBottomScroll)
-                    let previousScrollHeight = MyElement.scrollHeight;
-                    setTimeout( () => {
-                        if (MyElement.scrollHeight > previousScrollHeight) {
-                            const adjustment = MyElement.offsetHeight / 10; //When scrolling to the bottom, scroll up a 10% of the visible height to prevent to trigger the event again
-                            MyElement.scrollTop -= adjustment;
-                        }
-                    }, 10);
+            let currentScrollHeight = 0;
+
+            const checkScrollPosition = async () => {
+                let MyElement = element[0];
+                let latestHeightBottom = 50;
+                let scrollHeight = MyElement.scrollHeight;
+                let scrollPos = Math.floor(MyElement.offsetHeight + MyElement.scrollTop);
+                let isBottom = scrollHeight - latestHeightBottom < scrollPos;
+                if (isBottom && currentScrollHeight < scrollHeight) {
+                    let oldScrollTop = MyElement.scrollTop;
+                    await scope.$eval(attrs.ngBottomScroll);
+                    currentScrollHeight = scrollHeight;
+                    if(Math.floor(MyElement.offsetHeight + MyElement.scrollTop) ==  MyElement.scrollHeight){// if adding element did not scroll up then we do it
+                        MyElement.scrollTop = oldScrollTop;
+                    }
                 }
-            })
+            };
+
+            element.bind('scroll', checkScrollPosition);
         }
-    }
+    };
 });
+


### PR DESCRIPTION
## Describe your changes
Fixed an issue where when you scrolled too much mails, the infinit scroll event was triggered again in a loop

## Checklist tests
In a folder with a lot of mail try to scroll a lot without stopping, and check if mail keep getting loaded

## Issue ticket number and link
[MZI-189](https://jira.support-ent.fr/browse/MZI-189)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)